### PR TITLE
fix link in go/services to really point to the go sdk

### DIFF
--- a/docs/develop/go/services.mdx
+++ b/docs/develop/go/services.mdx
@@ -5,7 +5,7 @@ icon: "brackets-curly"
 ---
 
 
-The Restate Go SDK is open source and available on [GitHub](https://github.com/restatedev/sdk-typescript).
+The Restate Go SDK is open source and available on [GitHub](https://github.com/restatedev/sdk-go).
 
 The Restate SDK lets you implement **handlers**. Handlers can be part of a **[Basic Service](/foundations/services#basic-service)**, a **[Virtual Object](/foundations/services#virtual-object)**, or a **[Workflow](/foundations/services#workflow)**. This page shows how to define them with the Go SDK.
 


### PR DESCRIPTION
The link was incorrectly pointing to the typescript sdk.