### PR TITLE
Add networking configuration documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -241,6 +241,7 @@
                 ]
               },
               "server/configuration",
+              "server/networking",
               "server/clusters",
               "server/snapshots",
               "server/upgrading",

--- a/docs/guides/local-to-replicated.mdx
+++ b/docs/guides/local-to-replicated.mdx
@@ -111,14 +111,19 @@ Make sure to [upgrade](/server/upgrading) your single-node deployment to the lat
 
 <Step title="Turn a single-node into a multi-node deployment">
 
-    To add more nodes to your cluster, you need to start new Restate servers with the same `cluster-name` and a metadata client with the address of the existing node.
+    To add more nodes to your cluster, you need to start new Restate servers with the same `cluster-name` and configure the metadata client with the address of at least one existing node running the metadata-server role.
 
     ```toml restate.toml
     cluster-name = "my-cluster"
 
     [metadata-client]
+    # Point to at least one peer running metadata-server role
     addresses = ["http://metadata-node.cluster:5122"]
     ```
+
+    <Info>
+        Nodes automatically include themselves if they run the metadata-server role, so you only need to list peer addresses.
+    </Info>
 
     Metadata is critical to the operation of your cluster and we recommend that you run the `metadata-server` role on additional nodes. Make the cluster metadata service resilient to node failures by specifying the full list of metadata servers on all cluster nodes.
 

--- a/docs/references/server-config.mdx
+++ b/docs/references/server-config.mdx
@@ -494,8 +494,17 @@ Examples:
 
         </ResponseField>
 
+        <ResponseField name="advertised-address" type="string | null" post={['default=null','format: uri']}>
+            Advertised address: The URL that clients and other nodes will use to connect to this Admin API.
+
+If not set, the advertised address is automatically derived from the bound address and the global `advertised-host` setting.
+
+        </ResponseField>
+
         <ResponseField name="advertised-admin-endpoint" type="string" post={['default=null','format: uri']}>
-            Advertised Admin endpoint: Optional advertised Admin API endpoint.
+            **[Deprecated]** Use `advertised-address` instead.
+
+Advertised Admin endpoint: Optional advertised Admin API endpoint.
 
         </ResponseField>
 
@@ -612,8 +621,17 @@ Examples:
             </Expandable>
         </ResponseField>
 
+        <ResponseField name="advertised-address" type="string | null" post={['default=null','format: uri']}>
+            Advertised address: The URL that clients will use to connect to the Ingress API.
+
+If not set, the advertised address is automatically derived from the bound address and the global `advertised-host` setting.
+
+        </ResponseField>
+
         <ResponseField name="advertised-ingress-endpoint" type="string" post={['default=null','format: uri']}>
-            Ingress endpoint that the Web UI should use to interact with.
+            **[Deprecated]** Use `advertised-address` instead.
+
+Ingress endpoint that the Web UI should use to interact with.
 
         </ResponseField>
 
@@ -2039,13 +2057,52 @@ Examples:
     </Expandable>
 </ResponseField>
 
-<ResponseField name="bind-address" type="string" post={[]}>
-    Address to bind for the Node server. Derived from the advertised address, defaulting to `0.0.0.0:$PORT` (where the port will be inferred from the URL scheme).
+<ResponseField name="listen-mode" type="string" post={['default="all"']}>
+    Listen mode: Controls whether the server listens on TCP sockets, Unix domain sockets, or both.
+
+    - `"tcp"` : Exclusively listen on TCP sockets
+    - `"unix"` : Exclusively listen on Unix domain sockets
+    - `"all"` : [default] Listen on both Unix and TCP sockets
+
+When set to `all` (default), Restate creates Unix socket files under the data directory (`restate-data/*.sock`) in addition to TCP listeners. These sockets are automatically cleaned up on shutdown.
 
 </ResponseField>
 
-<ResponseField name="advertised-address" type="string" post={['default="http://127.0.0.1:5122/"']}>
-    Address that other nodes will use to connect to this node. Default is `http://127.0.0.1:5122/`
+<ResponseField name="use-random-ports" type="boolean" post={['default=false']}>
+    Use random ports: When enabled, Restate will select random available ports for all services instead of using the default ports. This is useful for testing or running multiple instances on the same host.
+
+The actual bound addresses are printed on startup. When using random ports with Unix sockets enabled (the default), tools can connect via the Unix socket paths which remain predictable.
+
+</ResponseField>
+
+<ResponseField name="bind-ip" type="string" post={['default="0.0.0.0"']}>
+    Bind IP: The local network interface IP address to bind on for all services. This is a convenience option that applies to all services unless overridden per-service.
+
+</ResponseField>
+
+<ResponseField name="bind-port" type="integer" post={['default=5122']}>
+    Bind port: The network port for the message fabric (node-to-node) service. Default is 5122.
+
+</ResponseField>
+
+<ResponseField name="bind-address" type="string" post={[]}>
+    Bind address: Combined `bind-ip:bind-port` for the message fabric service. This has precedence over the individual `bind-ip` and `bind-port` options.
+
+</ResponseField>
+
+<ResponseField name="advertised-host" type="string | null" post={['default=null']}>
+    Advertised hostname: Optional hostname to use when constructing advertised addresses. If not set, Restate will attempt to detect a publicly routable IP address automatically.
+
+This is useful when running behind a load balancer or in containerized environments where the auto-detected address may not be correct.
+
+</ResponseField>
+
+<ResponseField name="advertised-address" type="string | null" post={['default=null']}>
+    Advertised address: The full URL that other nodes will use to connect to this node's fabric service.
+
+If not set, the advertised address is automatically derived based on the listen mode and bound address. For TCP listeners, Restate attempts to detect a publicly routable IP address. For Unix-only mode, it advertises the Unix socket path.
+
+Examples: `http://192.168.1.10:5122/`, `https://my-host.example.com:5122/`, `unix:restate-data/fabric.sock`
 
 </ResponseField>
 

--- a/docs/server/clusters.mdx
+++ b/docs/server/clusters.mdx
@@ -11,6 +11,10 @@ This page helps with deploying and operating [Restate clusters](/deploy/server/c
     To understand the terminology used on this page, it might be helpful to read through the [architecture reference](/references/architecture).
 </Info>
 
+<Info>
+    For details on configuring network ports, addresses, and listeners, see the [networking guide](/server/networking).
+</Info>
+
 <Tip>
     To migrate an existing single-node deployment into a multi-node deployment without losing data, check out [this guide](/guides/local-to-replicated).
 </Tip>
@@ -116,8 +120,6 @@ To deploy a distributed Restate cluster without external dependencies, you need 
 node-name = "UNIQUE_NODE_NAME"
 # All nodes need to have the same cluster name
 cluster-name = "CLUSTER_NAME"
-# It is crucial that all peer nodes are able to resolve and connect to every other node's advertised address
-advertised-address = "ADVERTISED_ADDRESS"
 # Optional: Specify the location of this node for location-aware replication
 # Format: "region[.zone]" (e.g., "us-west.a1" or "eu-central")
 location = "REGION[.ZONE]"
@@ -135,30 +137,37 @@ auto-provision = false
 # For location-aware replication, you can use: {zone: 2, node: 3} or {region: 2, zone: 3, node: 5}
 default-replication = 2
 
-[bifrost]
-# Only the replicated Bifrost provider can be used in a distributed deployment
-default-provider = "replicated"
+# Optional: Override the auto-detected advertised address if needed
+# advertised-address = "http://NODE_PUBLIC_IP:5122/"
+# Or just set the hostname and let Restate derive the full URL:
+# advertised-host = "NODE_PUBLIC_HOSTNAME"
 
-[metadata-server]
-# To tolerate node failures, use the replicated metadata server
-type = "replicated"
+# Make sure it does not conflict with the other nodes when running multiple nodes on same host
+# [default] 5122
+bind-port = FABRIC_BIND_PORT
+
 
 [metadata-client]
-# List all the advertised addresses of the nodes that run the metadata-server role
-addresses = ["ADVERTISED_ADDRESS_1", "ADVERTISED_ADDRESS_2", ...]
+# List the advertised addresses of at least one node that runs the metadata-server role
+# This node will auto-include itself if it runs the metadata-server role
+addresses = ["PEER_ADVERTISED_FABRIC_ADDRESS"]
 
 [admin]
-# Make sure it does not conflict with the other nodes
-bind-address = "ADMIN_BIND_ADDRESS"
+# Make sure it does not conflict with the other nodes when running multiple nodes on same host
+bind-port = ADMIN_BIND_PORT
 
 [ingress]
-# Make sure it does not conflict with other nodes
-bind-address = "INGRESS_BIND_ADDRESS"
+# Make sure it does not conflict with other nodes when running multiple nodes on same host
+bind-port = INGRESS_BIND_PORT
 ```
 
 It is important that every Restate node you start has a **unique `node-name`** specified.
 The node name defaults to the hostname. Restate uses a subdirectory inside `restate-data` named after the node name to store local data. You will not be able to change the node name once it is in use without removing the node from the cluster, or else risk data loss.
 Nodes can have identical configurations aside from node name.
+
+<Info>
+    As of Restate v1.6, the server automatically detects a publicly routable IP address for the advertised address. You only need to explicitly set `advertised-address` or `advertised-host` if the auto-detection doesn't work for your environment (e.g., behind certain NAT configurations or load balancers).
+</Info>
 
 All nodes that are part of the cluster need to have the same `cluster-name` specified.
 
@@ -180,14 +189,14 @@ Refer to the [Cluster provisioning](#cluster-provisioning) section for more info
 
 The replicated log provider must be used with `default-provider = "replicated"` (this is the default).
 The `default-replication` determines the minimum number of nodes the data must be replicated to for both log and partition replication.
-If you run at least `2 * default-replication-property - 1` nodes, then the cluster can tolerate `default-replication-property - 1` node failures.
+If you run at least `2 * default-replication - 1` nodes, then the cluster can tolerate `default-replication - 1` node failures.
 Nodes running the `log-server` role store segments of replicated logs.
 
 Metadata availability is crucial for cluster availability, and the default metadata server type `replicated` can tolerate node failures.
 Every node that runs the `metadata-server` role will join the metadata store cluster.
 To tolerate `n` metadata node failures, you need to run at least `2 * n + 1` Restate nodes with the `metadata-server` role configured.
 
-The `metadata-client` should be configured with the advertised addresses of all nodes that run the `metadata-server` role.
+The `metadata-client` should be configured with at least one advertised address of a node that runs the `metadata-server` role. Nodes automatically include themselves if they run the metadata-server role, so for single-node setups, this field can be left empty.
 
 Restate nodes running the `worker` role host partitions and handle service invocations, journaling execution, and data storage and queries. The `default-replication` property sets the total number of replicas that the cluster will schedule for any given partition. Only one of these partitions is designated as a leader and actively processes invocations; additional partition replicas are followers and serve as hot standby in case they need to take over processing. Running additional partition replicas does not increase durability, which is determined by log replication and object store snapshots, however it can increase system availability by ensuring a new partition leader can be quickly promoted.
 

--- a/docs/server/configuration.mdx
+++ b/docs/server/configuration.mdx
@@ -11,6 +11,10 @@ The Restate Server has a wide range of configuration options to tune it accordin
     To learn about the configuration options, have a look at the [full configuration reference](/references/server-config).
 </Info>
 
+<Info title="Networking Configuration">
+    For details on configuring network ports, addresses, and listeners, see the [networking guide](/server/networking).
+</Info>
+
 ## Configuration file
 
 The Restate Server accepts a [TOML](https://toml.io/en/) configuration file that can be specified either providing the command-line option `--config-file=<PATH>` or setting the environment variable `RESTATE_CONFIG=<PATH>`. If not set, the [default configuration](/references/server-config#default-configuration) will be applied.

--- a/docs/server/networking.mdx
+++ b/docs/server/networking.mdx
@@ -1,0 +1,379 @@
+---
+title: "Networking"
+sidebar_position: 3
+description: "Configure network ports, addresses, and listeners for Restate Server"
+icon: "network-wired"
+---
+
+This page covers how to configure network listeners, ports, and advertised addresses for Restate Server.
+
+## Overview
+
+Restate Server exposes several network services:
+
+| Service | Default Port | Description |
+|---------|-------------|-------------|
+| **Ingress** | 8080 | HTTP API for invoking services and managing invocations |
+| **Admin** | 9070 | Admin API for registering deployments and introspection |
+| **Fabric** | 5122 | Node-to-node communication for clustered deployments |
+
+By default, Restate listens on both TCP sockets and Unix domain sockets for each service.
+
+## Listen Modes
+
+Restate supports three listen modes controlled by the `listen-mode` configuration option:
+
+| Mode | Description |
+|------|-------------|
+| `all` | **[Default]** Listen on both TCP and Unix sockets |
+| `tcp` | Only listen on TCP sockets |
+| `unix` | Only listen on Unix domain sockets |
+
+```toml restate.toml
+# Listen on TCP only (useful if Unix sockets are not needed)
+listen-mode = "tcp"
+```
+
+Or via environment variable:
+```bash
+RESTATE_LISTEN_MODE=tcp
+```
+
+### Unix Domain Sockets
+
+When Unix sockets are enabled (the default), Restate creates socket files under the data directory:
+
+| Service | Socket Path |
+|---------|-------------|
+| Ingress | `restate-data/<node-name>/ingress.sock` |
+| Admin | `restate-data/<node-name>/admin.sock` |
+| Fabric | `restate-data/<node-name>/fabric.sock` |
+
+Unix sockets are automatically cleaned up on shutdown. They are useful for:
+- Local development without port conflicts
+- Tools like `curl` that support `--unix-socket`
+- Secure local communication without exposing network ports
+
+**Example using Unix sockets with curl:**
+```bash
+curl --unix-socket restate-data/node-1/ingress.sock http://local/MyService/myHandler --json '{}'
+```
+
+**Example using Unix sockets with restatectl:**
+```bash
+restatectl -s unix:restate-data/node-1/admin.sock status
+```
+
+## Cascading Configuration
+
+Networking configuration follows a cascading model where global options provide defaults that can be overridden per-service. The resolution order is:
+
+1. **Global options** (top-level in config file) apply to all services
+2. **Per-service options** (in `[admin]`, `[ingress]` sections) override global options for that specific service
+3. **Environment variables** override config file values
+4. **Command-line arguments** have the highest precedence
+
+For example, if you set `bind-ip = "192.168.1.10"` at the top level, all services will bind to that IP unless a specific service overrides it with its own `bind-address`.
+
+The following options cascade from global to per-service:
+- `use-random-ports`
+- `listen-mode`
+- `bind-ip`
+- `advertised-host`
+
+The following options have per-service defaults and can be overridden individually:
+- `bind-port` (each service has its own default port)
+- `advertised-address` (auto-generated per service, but can be explicitly set for full control)
+
+## Configuring Ports and Addresses
+
+### Global Options
+
+These options apply to all services unless overridden per-service:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `bind-ip` | `0.0.0.0` | Local interface IP to bind on |
+| `bind-port` | `5122` | Port for the fabric service |
+| `use-random-ports` | `false` | Use random available ports instead of defaults |
+| `advertised-host` | Auto-detected | Hostname to advertise to peers |
+
+```toml restate.toml
+# Bind all services to a specific interface
+bind-ip = "192.168.1.10"
+
+# Or use random ports (useful for testing)
+use-random-ports = true
+```
+
+### Per-Service Configuration
+
+Each service can override the global settings. Use `bind-port` to change just the port while keeping the default bind IP (`0.0.0.0`):
+
+```toml restate.toml
+# Fabric service (node-to-node) - uses global bind-ip with custom port
+bind-port = 5122
+
+[admin]
+# Override just the port
+bind-port = 9070
+
+[ingress]
+# Override just the port
+bind-port = 8080
+```
+
+Or use `bind-address` for full control over both IP and port:
+
+```toml restate.toml
+[admin]
+bind-address = "192.168.1.10:9070"
+
+[ingress]
+bind-address = "192.168.1.10:8080"
+```
+
+### Environment Variable Overrides
+
+All networking options can be set via environment variables:
+
+| Config Option | Environment Variable |
+|---------------|---------------------|
+| `listen-mode` | `RESTATE_LISTEN_MODE` |
+| `use-random-ports` | `RESTATE_USE_RANDOM_PORTS` |
+| `bind-ip` | `RESTATE_BIND_IP` |
+| `bind-port` | `RESTATE_BIND_PORT` |
+| `bind-address` | `RESTATE_BIND_ADDRESS` |
+| `advertised-host` | `RESTATE_ADVERTISED_HOST` |
+| `advertised-address` | `RESTATE_ADVERTISED_ADDRESS` |
+
+Per-service overrides use double underscores:
+```bash
+RESTATE_ADMIN__BIND_PORT=9070
+RESTATE_INGRESS__BIND_PORT=8080
+```
+
+## Advertised Addresses
+
+Advertised addresses are the URLs that Restate publishes for others to connect to its services. Each service has its own advertised address that is **automatically generated** based on the bound address and detected network configuration. You can optionally set these explicitly if you need full control.
+
+<Note>
+Restate does **not** validate the reachability of advertised addresses. It trusts that the configured addresses are correct and reachable by the intended clients or peers.
+</Note>
+
+### Fabric Advertised Address
+
+The **fabric advertised address** (configured at the top level) is the network address that cluster nodes use to communicate with each other. This is the most critical advertised address and requires careful consideration:
+
+- **Must be resolvable and reachable** from all other nodes in the cluster
+- **Should not be behind a proxy** to avoid performance issues or connectivity problems
+- **Should be unique** within the cluster
+
+<Warning>
+We recommend using **IP addresses** rather than DNS names for the fabric advertised address. This avoids DNS resolution latency, potential caching issues, and DNS-related errors during node-to-node communication. DNS names are supported but not recommended for production clusters.
+</Warning>
+
+```toml restate.toml
+# Recommended: Use IP address for cluster communication
+advertised-address = "http://10.0.1.15:5122/"
+```
+
+### Ingress Advertised Address
+
+The **ingress advertised address** is shared with:
+- The **Admin UI** (Web UI service playground)
+- The **Restate CLI** (`restate` command)
+
+This address needs to be accessible by users who invoke services through Restate. For example, when users run `restate whoami`, this is the address they will see for the ingress endpoint.
+
+Unlike the fabric address, it's perfectly fine to expose the ingress behind an HTTPS proxy or load balancer on a different host:
+
+```toml restate.toml
+[ingress]
+# Ingress exposed behind an HTTPS proxy
+advertised-address = "https://my-ingress.example.com/"
+```
+
+### Admin Advertised Address
+
+The **admin advertised address** is used by:
+- The **Restate CLI** for administrative operations
+- The **Admin UI** for deployment management
+
+This is the address shown when users run `restate whoami` for the admin endpoint. Like the ingress address, it can be behind a proxy if needed:
+
+```toml restate.toml
+[admin]
+# Admin API behind an HTTPS proxy
+advertised-address = "https://admin.example.com/"
+```
+
+### Auto-Detection
+
+Restate automatically generates advertised addresses for all services based on:
+
+1. The listen mode (TCP vs Unix)
+2. The bound address
+3. The publicly routable IP address of the host (auto-detected)
+
+For most deployments, especially single-node setups, you don't need to configure advertised addresses explicitly.
+
+### When to Set Explicitly
+
+You may want to explicitly set advertised addresses when:
+
+- Running ingress or admin behind a load balancer or reverse proxy
+- In containerized environments where auto-detection doesn't work correctly
+- Using NAT with specific port mappings
+- You want users to connect via a specific hostname or domain
+
+**Using `advertised-host` (recommended for simple cases):**
+```toml restate.toml
+# Restate will construct full URLs using this hostname with the correct ports
+advertised-host = "restate.mycompany.internal"
+```
+
+This sets the hostname for all services. Restate will construct URLs like:
+- Fabric: `http://restate.mycompany.internal:5122/`
+- Admin: `http://restate.mycompany.internal:9070/`
+- Ingress: `http://restate.mycompany.internal:8080/`
+
+**Using per-service `advertised-address` for full control:**
+```toml restate.toml
+# Cluster communication - use IP address, no proxy
+advertised-address = "http://10.0.1.15:5122/"
+
+[admin]
+# Admin API behind HTTPS proxy
+advertised-address = "https://admin.example.com/"
+
+[ingress]
+# Ingress behind HTTPS proxy on different host
+advertised-address = "https://api.example.com/"
+```
+
+### Docker and Kubernetes
+
+In Docker Compose or Kubernetes, set the fabric advertised address to the internal hostname that other containers/pods can resolve:
+
+```yaml
+environment:
+  # Use the container/service name for cluster communication
+  RESTATE_ADVERTISED_ADDRESS: "http://restate-node-1:5122"
+```
+
+This ensures nodes can reach each other using internal DNS names provided by Docker or Kubernetes. For ingress and admin, you may want to set separate advertised addresses pointing to your external load balancer or ingress controller.
+
+## Random Ports
+
+For testing or running multiple instances on the same host, enable random port selection:
+
+```bash
+restate-server --use-random-ports=true
+```
+
+Or via environment variable:
+```bash
+RESTATE_USE_RANDOM_PORTS=true restate-server
+```
+
+When using random ports:
+- Restate prints the actual bound addresses on startup
+- Unix sockets remain at predictable paths, so tools can connect via Unix socket while ports are dynamic
+- Use `restate-server --no-logo` to have the addresses printed first on stdout (useful for scripting)
+
+## Common Configurations
+
+### Local Development (Default)
+
+No configuration needed. Restate listens on:
+- TCP: `0.0.0.0:8080` (ingress), `0.0.0.0:9070` (admin), `0.0.0.0:5122` (fabric)
+- Unix: `restate-data/<node-name>/*.sock`
+
+### Multi-Node Cluster
+
+```toml restate.toml
+node-name = "node-1"
+cluster-name = "production"
+# We don't want this node to provision its own cluster
+auto-provision = false
+
+# Use IP address for reliable cluster communication
+# You don't need to specify this if this IP address is the public routable IP address of the host (it'll be auto-detected)
+advertised-address = "http://10.0.1.15:5122/"
+
+[metadata-client]
+# Point to at least one peer running metadata-server role
+addresses = ["http://10.0.1.16:5122"]
+```
+
+### Running Multiple Instances on Same Host
+
+When running multiple Restate instances on the same host, each instance needs unique ports and a separate data directory:
+
+```toml restate-1.toml
+# Instance 1
+node-name = "node-1"
+cluster-name = "test-cluster"
+```
+
+```toml restate-2.toml
+# Instance 2
+node-name = "node-2"
+cluster-name = "test-cluster"
+# We don't want this node to provision its own cluster
+auto-provision = false
+
+bind-port = 5123
+
+[admin]
+bind-port = 9071
+
+[ingress]
+bind-port = 8081
+
+
+# Important to join the same cluster as node-1. Connect to node-1's metadata-server to join the cluster.
+[metadata-client]
+addresses = ["http://127.0.0.1:5122"]
+```
+
+Start each instance with its config file. It's best to run each instance in its own terminal window to avoid confusion:
+
+First node:
+```bash
+restate-server -c restate-1.toml
+```
+The second node:
+```bash
+restate-server -c restate-2.toml &
+```
+
+### TCP Only (No Unix Sockets)
+
+```toml restate.toml
+listen-mode = "tcp"
+```
+
+## CLI Options
+
+Networking options can also be set via command-line flags:
+
+```bash
+restate-server \
+  --listen-mode=tcp \
+  --bind-ip=0.0.0.0 \
+  --bind-port=5122 \
+  --advertised-host=my-host.example.com
+```
+
+Use `restate-server --help` for the full list of CLI options.
+
+## Deprecated Options
+
+The following options are deprecated and will be removed in a future release:
+
+| Deprecated Option | Replacement |
+|-------------------|-------------|
+| `[admin] advertised-admin-endpoint` | `[admin] advertised-address` |
+| `[ingress] advertised-ingress-endpoint` | `[ingress] advertised-address` |

--- a/docs/snippets/common/default-configuration.mdx
+++ b/docs/snippets/common/default-configuration.mdx
@@ -2,7 +2,12 @@
 
 The following is the default configuration. It does not include all possible configuration options, since some can be conflicting. Take a look at the configuration reference below for a full list of options.
 
-Note that configuration defaults might change across server releases, if you want to make sure you use stable values, use an explicit configuration file an pass the path via `--config-path=<PATH>` as described above.
+Note that configuration defaults might change across server releases, if you want to make sure you use stable values, use an explicit configuration file and pass the path via `--config-path=<PATH>` as described above.
+
+**Important changes in recent versions:**
+- Restate now listens on both TCP and Unix sockets by default (`listen-mode = "all"`). Unix sockets are created under `restate-data/*.sock`.
+- Advertised addresses are automatically detected based on your network configuration. You no longer need to explicitly set `advertised-address` for most deployments.
+- The `metadata-client.addresses` field is now optional for single-node setups.
 
 ```toml restate.toml expandable {"CODE_LOAD::../docs/schemas/restate.toml"} 
 roles = [
@@ -14,7 +19,12 @@ roles = [
 ]
 cluster-name = "localcluster"
 auto-provision = true
-advertised-address = "http://127.0.0.1:5122/"
+# listen-mode = "all"  # Can be "tcp", "unix", or "all" (default)
+# use-random-ports = false
+# bind-ip = "0.0.0.0"
+# bind-port = 5122  # Fabric port
+# advertised-host = "my-hostname"  # Optional, auto-detected if not set
+# advertised-address = "http://127.0.0.1:5122/"  # Optional, auto-detected if not set
 default-num-partitions = 24
 default-replication = 1
 shutdown-timeout = "1m"
@@ -49,7 +59,8 @@ default-journal-retention = "1d"
 
 [metadata-client]
 type = "replicated"
-addresses = ["http://127.0.0.1:5122/"]
+# addresses is optional for single-node setups, auto-populated if this node runs metadata-server role
+addresses = []
 connect-timeout = "3s"
 keep-alive-interval = "5s"
 keep-alive-timeout = "5s"
@@ -103,6 +114,7 @@ max-interval = "10s"
 
 [admin]
 bind-address = "0.0.0.0:9070"
+# advertised-address = "http://127.0.0.1:9070/"  # Optional, auto-detected if not set
 heartbeat-interval = "1s 500ms"
 log-trim-check-interval = "1h"
 disable-web-ui = false
@@ -113,6 +125,7 @@ memory-size = "4.0 GiB"
 
 [ingress]
 bind-address = "0.0.0.0:8080"
+# advertised-address = "http://127.0.0.1:8080/"  # Optional, auto-detected if not set
 kafka-clusters = []
 
 [bifrost]


### PR DESCRIPTION

Add comprehensive documentation for Restate Server networking configuration
including the new options introduced in PR restatedev/restate#3892:

- New networking guide page (docs/server/networking.mdx) covering:
  - Listen modes (tcp, unix, all)
  - Unix domain sockets
  - Configuration cascading
  - Advertised addresses for fabric, ingress, and admin services
  - Common configuration patterns

- Updated server-config.mdx with new options:
  - listen-mode, use-random-ports, bind-ip, bind-port, advertised-host
  - Per-service advertised-address for admin and ingress
  - Marked advertised-admin-endpoint and advertised-ingress-endpoint as deprecated

- Updated clusters.mdx:
  - Simplified configuration examples (advertised-address is now optional)
  - Added note about auto-detection of advertised addresses
  - Clarified metadata-client.addresses requirements

- Updated restate.toml schema with new networking options

- Updated local-to-replicated.mdx guide with clarifications

Closes #87

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/docs-restate/pull/111).
* #129
* #127
* #120
* #113
* __->__ #111