### PR TITLE
Update docs regarding bind-address

### DIFF
--- a/docs/references/server-config.mdx
+++ b/docs/references/server-config.mdx
@@ -2040,7 +2040,7 @@ Examples:
 </ResponseField>
 
 <ResponseField name="bind-address" type="string" post={[]}>
-    Address to bind for the Node server. Derived from the advertised address, defaulting to `0.0.0.0:$PORT` (where the port will be inferred from the URL scheme).
+    Address to bind for the Node server. defaulting to `0.0.0.0:5122`.
 
 </ResponseField>
 

--- a/docs/schemas/restate-server-configuration-schema.json
+++ b/docs/schemas/restate-server-configuration-schema.json
@@ -258,7 +258,7 @@
       "$ref": "#/definitions/MetadataClientOptions"
     },
     "bind-address": {
-      "description": "Address to bind for the Node server. Derived from the advertised address, defaulting to `0.0.0.0:$PORT` (where the port will be inferred from the URL scheme).",
+      "description": "Address to bind for the Node server. defaulting to `0.0.0.0:5122`.",
       "type": "string"
     },
     "advertised-address": {

--- a/docs/schemas/restate.toml
+++ b/docs/schemas/restate.toml
@@ -1,12 +1,7 @@
-roles = [
-    "worker",
-    "admin",
-    "metadata-server",
-    "log-server",
-    "http-ingress",
-]
+roles = ["worker", "admin", "metadata-server", "log-server", "http-ingress"]
 cluster-name = "localcluster"
 auto-provision = true
+bind-address = "0.0.0.0:5122"
 advertised-address = "http://127.0.0.1:5122/"
 default-num-partitions = 24
 default-replication = 1
@@ -186,4 +181,3 @@ rocksdb-disable-wal-fsync = false
 rocksdb-max-sub-compactions = 0
 writer-batch-commit-count = 5000
 incoming-network-queue-length = 1000
-

--- a/docs/server/clusters.mdx
+++ b/docs/server/clusters.mdx
@@ -116,6 +116,8 @@ To deploy a distributed Restate cluster without external dependencies, you need 
 node-name = "UNIQUE_NODE_NAME"
 # All nodes need to have the same cluster name
 cluster-name = "CLUSTER_NAME"
+# Address to bind for the Node server.
+bind-address = "BIND_ADDRESS"
 # It is crucial that all peer nodes are able to resolve and connect to every other node's advertised address
 advertised-address = "ADVERTISED_ADDRESS"
 # Optional: Specify the location of this node for location-aware replication

--- a/docs/snippets/common/default-configuration.mdx
+++ b/docs/snippets/common/default-configuration.mdx
@@ -5,15 +5,10 @@ The following is the default configuration. It does not include all possible con
 Note that configuration defaults might change across server releases, if you want to make sure you use stable values, use an explicit configuration file an pass the path via `--config-path=<PATH>` as described above.
 
 ```toml restate.toml expandable {"CODE_LOAD::../docs/schemas/restate.toml"} 
-roles = [
-    "worker",
-    "admin",
-    "metadata-server",
-    "log-server",
-    "http-ingress",
-]
+roles = ["worker", "admin", "metadata-server", "log-server", "http-ingress"]
 cluster-name = "localcluster"
 auto-provision = true
+bind-address = "0.0.0.0:5122"
 advertised-address = "http://127.0.0.1:5122/"
 default-num-partitions = 24
 default-replication = 1


### PR DESCRIPTION
Update docs regarding bind-address

Summary:
Bind address are not derived from advertised-address anymore

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/docs-restate/pull/126).
* #133
* __->__ #126