### PR TITLE
Clarify API key role guidance for Cloud integrations

### DIFF
--- a/docs/cloud/connecting-services.mdx
+++ b/docs/cloud/connecting-services.mdx
@@ -279,7 +279,7 @@ View an example of deploying to AWS Lambda with SDK for your SDK here: [TS](http
 - The `RESTATE_ENV_ID` can be found in the Restate Cloud UI in the top left corner when you select your environment.
 This ID starts with `env_`.
 
-- For the `RESTATE_API_KEY`, create an API key via `Developers` tab of the Restate Cloud UI and give it `Full` permissions.
+- For the `RESTATE_API_KEY`, create an API key via `Developers` tab of the Restate Cloud UI and give it `Admin` permissions.
 
 The `RestateCloudEnvironment` automatically creates an IAM role with an appropriate trust policy for the matching Restate Cloud environment. The `ServiceDeployer` construct automatically grants this role permission to invoke any AWS Lambda functions registered with the environment. For more details, consult the relevant [Restate CDK](https://www.npmjs.com/package/@restatedev/restate-cdk) constructs' API documentation.
 
@@ -307,6 +307,8 @@ The tunnel can be hosted as a cloud VM in your VPC, a sidecar to your service, o
 
 You can deploy multiple copies for redundancy.
 
+Before starting the tunnel, create an API key via the `Developers` tab of the Restate Cloud UI and give it `Full` permissions. The tunnel needs this role because it exposes both the admin and ingress endpoints of your Restate Cloud environment. Also copy your environment's signing public key from `Developers` > `Security` > `HTTP endpoints`.
+
 To run the tunnel:
 
 ```bash
@@ -331,9 +333,9 @@ docker run \
 <AccordionGroup>
 <Accordion title="Environment variables">
 - `RESTATE_ENVIRONMENT_ID` is the environment id (including the `env_` prefix).
-- `RESTATE_BEARER_TOKEN` is the API key you created in step 1.
+- `RESTATE_BEARER_TOKEN` is the `Full` permissions API key you created above (starts with `key_`).
 - `RESTATE_TUNNEL_NAME` is a name for the tunnel. Choose a unique DNS-friendly tunnel name, e.g. `prod-tunnel`.
-- `RESTATE_SIGNING_PUBLIC_KEY` is the public key you copied from the Cloud UI in step 1.
+- `RESTATE_SIGNING_PUBLIC_KEY` is the public key you copied from the Cloud UI above (starts with `publickeyv1_`).
 - `RESTATE_CLOUD_REGION` is the region of your Restate Cloud environment, e.g. `eu` or `us`.
 - You can run `latest` or pin the current version, e.g. `0.4.0`
 - The health check URL is at `:9090/health`

--- a/docs/guides/connecting-k8s-services-to-cloud.mdx
+++ b/docs/guides/connecting-k8s-services-to-cloud.mdx
@@ -49,7 +49,7 @@ We will use [kind](https://kind.sigs.k8s.io/) to create a local Kubernetes clust
 
     Create an API key via `Developers` tab of the Restate Cloud UI and give it `Full` permissions.
 
-    The API key starts with `api_`. Put it in a file named `token` and add the secret:
+    The API key starts with `key_`. Put it in a file named `token` and add the secret:
     ```bash
     kubectl create secret generic my-cloud-environment-secret \
     --from-file=token=./token -n restate-operator


### PR DESCRIPTION
## Summary

Three small fixes to the Restate Cloud API key role guidance:

- **Lambda CDK `ServiceDeployer`** (`docs/cloud/connecting-services.mdx`): recommend `Admin` instead of `Full`. This construct only registers deployments via the admin API, so `Admin` is the right minimum role, matching the other CI/CD deployment pages (GitHub Actions for Lambda/Vercel/Deno/Cloudflare Workers).

- **API key prefix** (`docs/guides/connecting-k8s-services-to-cloud.mdx`): change `api_` to `key_`. Cloud API keys start with `key_`; the sibling page in `docs/cloud/connecting-services.mdx` already says this.

- **Private tunnel section** (`docs/cloud/connecting-services.mdx`): replace dangling "step 1" references in the env var accordion with inline guidance. The section had no step 1. Now it explicitly instructs users to create an API key with `Full` permissions and explains why: the tunnel client proxies both the admin and ingress endpoints, so `Admin` alone is insufficient.

## Role conventions confirmed

- **Tunnel client / Restate Operator** -> `Full` (FullAccess): the tunnel exposes ingress in addition to admin.
- **CI/CD deployment registration** -> `Admin` (AdminAccess): only needs to call the admin API.

## Test plan

- [ ] Preview the rendered pages in Mintlify and confirm the new paragraph in the private-tunnel section reads cleanly.
- [ ] Verify all three pages render without Mintlify warnings.