### PR TITLE
Use RESTATE_AUTH_TOKEN in CDK example for consistency with CLI

### DIFF
--- a/docs/cloud/connecting-services.mdx
+++ b/docs/cloud/connecting-services.mdx
@@ -252,16 +252,16 @@ export class LambdaTsCdkStack extends cdk.Stack {
       },
     });
 
-    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_API_KEY) {
+    if (!process.env.RESTATE_ENV_ID || !process.env.RESTATE_AUTH_TOKEN) {
       throw new Error(
-        "Required environment variables RESTATE_ENV_ID and RESTATE_API_KEY are not set, please see README.",
+        "Required environment variables RESTATE_ENV_ID and RESTATE_AUTH_TOKEN are not set, please see README.",
       );
     }
 
     const restateEnvironment = new restate.RestateCloudEnvironment(this, "RestateCloud", {
       environmentId: process.env.RESTATE_ENV_ID! as restate.EnvironmentId,
       apiKey: new secrets.Secret(this, "RestateCloudApiKey", {
-        secretStringValue: cdk.SecretValue.unsafePlainText(process.env.RESTATE_API_KEY!),
+        secretStringValue: cdk.SecretValue.unsafePlainText(process.env.RESTATE_AUTH_TOKEN!),
       }),
     });
     const deployer = new restate.ServiceDeployer(this, "ServiceDeployer");
@@ -279,7 +279,7 @@ View an example of deploying to AWS Lambda with SDK for your SDK here: [TS](http
 - The `RESTATE_ENV_ID` can be found in the Restate Cloud UI in the top left corner when you select your environment.
 This ID starts with `env_`.
 
-- For the `RESTATE_API_KEY`, create an API key via `Developers` tab of the Restate Cloud UI and give it `Full` permissions.
+- For the `RESTATE_AUTH_TOKEN`, create an API key via `Developers` tab of the Restate Cloud UI and give it `Full` permissions.
 
 The `RestateCloudEnvironment` automatically creates an IAM role with an appropriate trust policy for the matching Restate Cloud environment. The `ServiceDeployer` construct automatically grants this role permission to invoke any AWS Lambda functions registered with the environment. For more details, consult the relevant [Restate CDK](https://www.npmjs.com/package/@restatedev/restate-cdk) constructs' API documentation.
 


### PR DESCRIPTION
Just making things a bit more consistent across the board, received customer feedback that the different names are confusing.

## Summary

- Renames `RESTATE_API_KEY` to `RESTATE_AUTH_TOKEN` in the CDK example on `docs/cloud/connecting-services` (both the embedded code block and the standalone reference under it).
- Aligns this page with the Cloud getting-started page, the Restate CLI (which reads `RESTATE_AUTH_TOKEN`), and the Cloud UI's example snippets. A customer reported that the three different env var names across docs and tools tripped them up while configuring everything end-to-end.

## Notes

- The embedded CDK block is `CODE_LOAD`'d from `restatedev/examples` on `main`. The companion PR https://github.com/restatedev/examples/pull/389 renames the same vars in the source files. Once that merges, running `node scripts/loadScripts.js` is a no-op against this MDX. Until then, this PR temporarily desyncs the embedded block from upstream `main`, which is intentional.
- The tunnel client section further down the page still references `RESTATE_BEARER_TOKEN` — that's accurate to the tunnel binary's actual env var and out of scope for this PR.

## Test plan

- [ ] `npm run dev` renders the page without errors and the CDK block shows `RESTATE_AUTH_TOKEN` throughout
- [ ] After the companion examples PR merges, run `node scripts/loadScripts.js` locally and confirm there is no diff against this branch