### PR TITLE
Document native Google Cloud Run authentication

### DIFF
--- a/docs/cloud/connecting-services.mdx
+++ b/docs/cloud/connecting-services.mdx
@@ -15,7 +15,6 @@ You can connect your services to Restate Cloud in several ways, depending on whe
 - Connect [Kubernetes services](/cloud/connecting-services#kubernetes-services) via a secure tunnel with Restate Operator.
 - Connect [serverless functions (Vercel, Cloudflare Workers, Deno Deploy, etc.) or other public endpoints](/cloud/connecting-services#serverless-functions-and-other-public-endpoints), by signing requests with your cloud environment's public key.
 - Connect [AWS Lambda functions](#aws-lambda-functions), by granting Restate Cloud permission to assume a role in your AWS account.
-- Connect [Google Cloud Run services](#google-cloud-run), by minting Google OIDC ID tokens that Cloud Run validates.
 - Connect [services in private environments](#services-in-private-environments), by setting up a tunnel.
 
 If you prefer a video walkthrough, check out this webinar on getting started with cloud:
@@ -287,12 +286,6 @@ The `RestateCloudEnvironment` automatically creates an IAM role with an appropri
 The CDK also registers your service with Restate Cloud, so no need to do this manually.
 
 If something isn't working, the environment logs in the Cloud UI may help you find the issue.
-
-## Google Cloud Run
-
-Restate can natively invoke private Google Cloud Run services by minting short-lived, Google-signed OIDC ID tokens for each discovery and invocation request. Cloud Run validates the token before forwarding the request to your container, so you do not need to embed long-lived bearer tokens in your deployment configuration.
-
-See the [Google Cloud Run deployment guide](/services/deploy/cloud-run) for how to register a deployment with native authentication (`--gcp-id-token`, optionally with `--gcp-impersonate-service-account` and `--gcp-audience`), the required IAM roles, and credential setup for both Restate Cloud and self-hosted Restate.
 
 ## Services in private environments
 

--- a/docs/cloud/connecting-services.mdx
+++ b/docs/cloud/connecting-services.mdx
@@ -12,11 +12,11 @@ When using Restate Cloud, you can run your services anywhere: on Kubernetes, as 
 The only requirement is that your services need to be reachable from Restate Cloud's infrastructure.
 
 You can connect your services to Restate Cloud in several ways, depending on where they run:
-- Connect [Kubernetes services](/cloud/connecting-services#connecting-kubernetes-services) via a secure tunnel with Restate Operator.
+- Connect [Kubernetes services](/cloud/connecting-services#kubernetes-services) via a secure tunnel with Restate Operator.
 - Connect [serverless functions (Vercel, Cloudflare Workers, Deno Deploy, etc.) or other public endpoints](/cloud/connecting-services#serverless-functions-and-other-public-endpoints), by signing requests with your cloud environment's public key.
-- Connect [AWS Lambda functions](#connecting-aws-lambda-services), by granting Restate Cloud permission to assume a role in your AWS account.
+- Connect [AWS Lambda functions](#aws-lambda-functions), by granting Restate Cloud permission to assume a role in your AWS account.
 - Connect [Google Cloud Run services](#google-cloud-run), by minting Google OIDC ID tokens that Cloud Run validates.
-- Connect [services in private environments](#connecting-services-in-private-environments), by setting up a tunnel.
+- Connect [services in private environments](#services-in-private-environments), by setting up a tunnel.
 
 If you prefer a video walkthrough, check out this webinar on getting started with cloud:
 

--- a/docs/cloud/connecting-services.mdx
+++ b/docs/cloud/connecting-services.mdx
@@ -15,6 +15,7 @@ You can connect your services to Restate Cloud in several ways, depending on whe
 - Connect [Kubernetes services](/cloud/connecting-services#connecting-kubernetes-services) via a secure tunnel with Restate Operator.
 - Connect [serverless functions (Vercel, Cloudflare Workers, Deno Deploy, etc.) or other public endpoints](/cloud/connecting-services#serverless-functions-and-other-public-endpoints), by signing requests with your cloud environment's public key.
 - Connect [AWS Lambda functions](#connecting-aws-lambda-services), by granting Restate Cloud permission to assume a role in your AWS account.
+- Connect [Google Cloud Run services](#google-cloud-run), by minting Google OIDC ID tokens that Cloud Run validates.
 - Connect [services in private environments](#connecting-services-in-private-environments), by setting up a tunnel.
 
 If you prefer a video walkthrough, check out this webinar on getting started with cloud:
@@ -286,6 +287,12 @@ The `RestateCloudEnvironment` automatically creates an IAM role with an appropri
 The CDK also registers your service with Restate Cloud, so no need to do this manually.
 
 If something isn't working, the environment logs in the Cloud UI may help you find the issue.
+
+## Google Cloud Run
+
+Restate can natively invoke private Google Cloud Run services by minting short-lived, Google-signed OIDC ID tokens for each discovery and invocation request. Cloud Run validates the token before forwarding the request to your container, so you do not need to embed long-lived bearer tokens in your deployment configuration.
+
+See the [Google Cloud Run deployment guide](/services/deploy/cloud-run) for how to register a deployment with native authentication (`--gcp-id-token`, optionally with `--gcp-impersonate-service-account` and `--gcp-audience`), the required IAM roles, and credential setup for both Restate Cloud and self-hosted Restate.
 
 ## Services in private environments
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -179,6 +179,7 @@
                   "services/deploy/kubernetes",
                   "services/deploy/vercel",
                   "services/deploy/lambda",
+                  "services/deploy/cloud-run",
                   "services/deploy/cloudflare-workers",
                   "services/deploy/deno-deploy",
                   "services/deploy/standalone"

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -374,7 +374,7 @@ export default {
 
                         <Accordion title="Restate Cloud">
                             When using [Restate Cloud](https://restate.dev/cloud), your service must be accessible over the public internet so Restate can invoke it.
-                            If you want to develop with a local service, you can expose it using our [tunnel](/cloud/connecting-services#connecting-services-in-private-environments) feature.
+                            If you want to develop with a local service, you can expose it using our [tunnel](/cloud/connecting-services#services-in-private-environments) feature.
                         </Accordion>
                     </Step>
                     <Step title="Send a request to the Greeter service">

--- a/docs/services/deploy/cloud-run.mdx
+++ b/docs/services/deploy/cloud-run.mdx
@@ -1,0 +1,149 @@
+---
+title: "Google Cloud Run"
+description: "Run your Restate services on Google Cloud Run with native OIDC authentication"
+---
+
+Deploy your Restate services as containers on Google Cloud Run. Restate
+can invoke private Cloud Run services natively by minting short-lived,
+Google-signed OIDC ID tokens for each discovery and invocation request.
+
+## Set up your service on Cloud Run
+
+Package your Restate service as a container image and deploy it to Cloud
+Run following the [Cloud Run documentation](https://cloud.google.com/run/docs/deploying).
+A typical Restate service exposes its handler on port `9080`; configure
+the Cloud Run service to forward traffic to whichever port your container
+listens on.
+
+For a private Cloud Run service, leave the default access policy in
+place (no unauthenticated invocations). Restate authenticates to the
+service using a Google OIDC ID token, which Cloud Run validates before
+forwarding the request to your container.
+
+## Register the service with native authentication
+
+When registering an HTTP deployment, opt into native Google OIDC
+authentication with `--gcp-id-token`. Restate mints a Google-signed ID
+token for every discovery and invocation request and attaches it as
+`X-Serverless-Authorization: Bearer <token>`. Cloud Run validates this
+header in precedence over `Authorization` and strips it before forwarding
+the request to your container, so any `Authorization` value you set via
+`--extra-header` reaches the workload unchanged.
+
+```shell
+restate deployments register https://svc-abc-uc.a.run.app --gcp-id-token
+```
+
+To call the Cloud Run service as a specific service account, impersonate
+it via the IAM Credentials `generateIdToken` API:
+
+```shell
+restate deployments register https://svc-abc-uc.a.run.app \
+  --gcp-impersonate-service-account caller@my-proj.iam.gserviceaccount.com
+```
+
+`--gcp-impersonate-service-account` implies `--gcp-id-token`.
+
+### Custom domains and audience overrides
+
+By default, Restate derives the OIDC `aud` claim from the deployment URL
+origin (scheme, host, and optional port). If your Cloud Run service sits
+behind a custom domain, a load balancer, or a traffic tag, set the
+audience explicitly to the canonical Cloud Run service URL:
+
+```shell
+restate deployments register https://api.acme.com/svc \
+  --gcp-audience https://svc-abc-uc.a.run.app
+```
+
+`--gcp-audience` also implies `--gcp-id-token`.
+
+### Updating or removing authentication
+
+Authentication configuration is set when the deployment is registered.
+To rotate the impersonation target, change the audience, or remove
+authentication entirely, re-register with `--force`:
+
+```shell
+# Change the impersonation target:
+restate deployments register https://svc-abc-uc.a.run.app --force \
+  --gcp-impersonate-service-account new-caller@my-proj.iam.gserviceaccount.com
+
+# Remove authentication:
+restate deployments register https://svc-abc-uc.a.run.app --force
+```
+
+This mirrors how the [Lambda `--assume-role-arn`](/services/deploy/lambda#register-the-service-to-restate)
+flow is updated for AWS deployments.
+
+## Credentials available to Restate
+
+Restate discovers credentials through Google's [Application Default
+Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials)
+chain. Not every ADC source can mint an OIDC ID token directly; the table
+below summarizes what works.
+
+| ADC source | Ambient `--gcp-id-token` | With `--gcp-impersonate-service-account` |
+|------------|--------------------------|------------------------------------------|
+| GCE / GKE / Cloud Run metadata server | Supported | Supported |
+| Service-account JSON key file | Supported | Supported |
+| Workload Identity Federation (`external_account`) | Not supported | Supported |
+| User credentials from `gcloud auth application-default login` (`authorized_user`) | Not supported | Supported |
+
+When the ambient identity cannot mint ID tokens for arbitrary audiences,
+pair it with `--gcp-impersonate-service-account` so Restate calls the IAM
+Credentials `generateIdToken` API on a target service account that the
+ambient identity is authorized to impersonate.
+
+### IAM roles
+
+The principal whose identity ends up in the minted token must hold:
+
+- `roles/run.invoker` on the target Cloud Run service, so that Cloud
+  Run IAM accepts the request.
+- `roles/iam.serviceAccountOpenIdTokenCreator` on the impersonation
+  target, when `--gcp-impersonate-service-account` is used.
+
+### Self-hosted Restate
+
+For self-hosted Restate calling private Cloud Run services, ensure one
+of the following:
+
+- The Restate process can reach Google's metadata server (typical on
+  GCE, GKE, or Cloud Run hosts), or
+- `GOOGLE_APPLICATION_CREDENTIALS` points to a service-account JSON key
+  file readable by the Restate user.
+
+Restate does not contact any Google API or read any ADC source until the
+first deployment with native authentication enabled is observed.
+
+### Local development
+
+For local development, run `gcloud auth application-default login` to
+populate ADC. This is distinct from `gcloud auth login`, which only
+populates user credentials for the `gcloud` tool itself.
+
+Authorized-user ADC credentials cannot mint ID tokens for arbitrary
+audiences without impersonation, so pair them with
+`--gcp-impersonate-service-account` for the dev flow.
+
+## Token caching and rotation
+
+Tokens are minted on demand and cached per
+`(impersonate_service_account, audience)` pair on the invoker. Cached
+tokens are evicted 60 seconds before expiry so that every outbound
+request carries a token with sufficient lifetime. Discovery requests do
+not cache tokens; a fresh token is minted for each discovery call,
+matching the existing Lambda assume-role behavior.
+
+## Comparison with Lambda authentication
+
+| | AWS Lambda | Google Cloud Run |
+|---|---|---|
+| Mechanism | STS `AssumeRole` | Google OIDC ID token |
+| Credential flag | `--assume-role-arn <ROLE_ARN>` | `--gcp-id-token` (optionally with `--gcp-impersonate-service-account` and `--gcp-audience`) |
+| Header sent to target | Signed AWS SigV4 invoke | `X-Serverless-Authorization: Bearer <token>` |
+| Target validation | Lambda invoke IAM | Cloud Run IAM (validates token, then strips header) |
+
+See the [AWS Lambda deployment guide](/services/deploy/lambda) for the
+parallel AWS flow.

--- a/docs/services/deploy/cloud-run.mdx
+++ b/docs/services/deploy/cloud-run.mdx
@@ -3,39 +3,33 @@ title: "Google Cloud Run"
 description: "Run your Restate services on Google Cloud Run with native OIDC authentication"
 ---
 
-Deploy your Restate services as containers on Google Cloud Run. Restate
-can invoke private Cloud Run services natively by minting short-lived,
-Google-signed OIDC ID tokens for each discovery and invocation request.
+Deploy your Restate services as containers on Google Cloud Run. Restate can invoke private Cloud Run services natively by minting short-lived, Google-signed OIDC ID tokens for each discovery and invocation request.
 
 ## Set up your service on Cloud Run
 
-Package your Restate service as a container image and deploy it to Cloud
-Run following the [Cloud Run documentation](https://cloud.google.com/run/docs/deploying).
-A typical Restate service exposes its handler on port `9080`; configure
-the Cloud Run service to forward traffic to whichever port your container
-listens on.
+Package your Restate service as a container image and deploy it to Cloud Run following the [Cloud Run documentation](https://cloud.google.com/run/docs/deploying). A typical Restate service exposes its handler on port `9080`; configure the Cloud Run service to forward traffic to whichever port your container listens on.
 
-For a private Cloud Run service, leave the default access policy in
-place (no unauthenticated invocations). Restate authenticates to the
-service using a Google OIDC ID token, which Cloud Run validates before
-forwarding the request to your container.
+Restate's service deployment protocol uses HTTP/2 (h2c), so the Cloud Run service must use end-to-end HTTP/2 to the container. Enable it when you deploy with `--use-http2` (equivalently, the `run.googleapis.com/use-http2` annotation); without it, discovery and invocation fail with an upstream `protocol error`.
+
+```shell
+gcloud run deploy my-restate-service \
+  --image <IMAGE> \
+  --port 9080 \
+  --use-http2 \
+  --no-allow-unauthenticated
+```
+
+For a private Cloud Run service, leave the default access policy in place (no unauthenticated invocations). Restate authenticates to the service using a Google OIDC ID token, which Cloud Run validates before forwarding the request to your container.
 
 ## Register the service with native authentication
 
-When registering an HTTP deployment, opt into native Google OIDC
-authentication with `--gcp-id-token`. Restate mints a Google-signed ID
-token for every discovery and invocation request and attaches it as
-`X-Serverless-Authorization: Bearer <token>`. Cloud Run validates this
-header in precedence over `Authorization` and strips it before forwarding
-the request to your container, so any `Authorization` value you set via
-`--extra-header` reaches the workload unchanged.
+When registering an HTTP deployment, opt into native Google OIDC authentication with `--gcp-id-token`. Restate mints a Google-signed ID token for every discovery and invocation request and attaches it as `X-Serverless-Authorization: Bearer <token>`. Cloud Run validates this header in precedence over `Authorization` and strips it before forwarding the request to your container, so any `Authorization` value you set via `--extra-header` reaches the workload unchanged.
 
 ```shell
 restate deployments register https://svc-abc-uc.a.run.app --gcp-id-token
 ```
 
-To call the Cloud Run service as a specific service account, impersonate
-it via the IAM Credentials `generateIdToken` API:
+To call the Cloud Run service as a specific service account, impersonate it via the IAM Credentials `generateIdToken` API:
 
 ```shell
 restate deployments register https://svc-abc-uc.a.run.app \
@@ -46,10 +40,7 @@ restate deployments register https://svc-abc-uc.a.run.app \
 
 ### Custom domains and audience overrides
 
-By default, Restate derives the OIDC `aud` claim from the deployment URL
-origin (scheme, host, and optional port). If your Cloud Run service sits
-behind a custom domain, a load balancer, or a traffic tag, set the
-audience explicitly to the canonical Cloud Run service URL:
+By default, Restate derives the OIDC `aud` claim from the deployment URL origin (scheme, host, and optional port). If your Cloud Run service sits behind a custom domain, a load balancer, or a traffic tag, set the audience explicitly to the canonical Cloud Run service URL:
 
 ```shell
 restate deployments register https://api.acme.com/svc \
@@ -60,9 +51,7 @@ restate deployments register https://api.acme.com/svc \
 
 ### Updating or removing authentication
 
-Authentication configuration is set when the deployment is registered.
-To rotate the impersonation target, change the audience, or remove
-authentication entirely, re-register with `--force`:
+Authentication configuration is set when the deployment is registered. To rotate the impersonation target, change the audience, or remove authentication entirely, re-register with `--force`:
 
 ```shell
 # Change the impersonation target:
@@ -73,15 +62,11 @@ restate deployments register https://svc-abc-uc.a.run.app --force \
 restate deployments register https://svc-abc-uc.a.run.app --force
 ```
 
-This mirrors how the [Lambda `--assume-role-arn`](/services/deploy/lambda#register-the-service-to-restate)
-flow is updated for AWS deployments.
+Re-registration with `--force` re-runs discovery against the deployment, so the new configuration must itself be able to reach the service. Removing authentication from a service that still requires authenticated invocations therefore fails at discovery with `403 Forbidden`; only remove authentication once the service accepts the request without a token.
 
 ## Credentials available to Restate
 
-Restate discovers credentials through Google's [Application Default
-Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials)
-chain. Not every ADC source can mint an OIDC ID token directly; the table
-below summarizes what works.
+Restate discovers credentials through Google's [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials) chain. Not every ADC source can mint an OIDC ID token directly; the table below summarizes what works.
 
 | ADC source | Ambient `--gcp-id-token` | With `--gcp-impersonate-service-account` |
 |------------|--------------------------|------------------------------------------|
@@ -90,60 +75,30 @@ below summarizes what works.
 | Workload Identity Federation (`external_account`) | Not supported | Supported |
 | User credentials from `gcloud auth application-default login` (`authorized_user`) | Not supported | Supported |
 
-When the ambient identity cannot mint ID tokens for arbitrary audiences,
-pair it with `--gcp-impersonate-service-account` so Restate calls the IAM
-Credentials `generateIdToken` API on a target service account that the
-ambient identity is authorized to impersonate.
+When the ambient identity cannot mint ID tokens for arbitrary audiences, pair it with `--gcp-impersonate-service-account` so Restate calls the IAM Credentials `generateIdToken` API on a target service account that the ambient identity is authorized to impersonate.
 
 ### IAM roles
 
 The principal whose identity ends up in the minted token must hold:
 
-- `roles/run.invoker` on the target Cloud Run service, so that Cloud
-  Run IAM accepts the request.
-- `roles/iam.serviceAccountOpenIdTokenCreator` on the impersonation
-  target, when `--gcp-impersonate-service-account` is used.
+- `roles/run.invoker` on the target Cloud Run service, so that Cloud Run IAM accepts the request.
+- `roles/iam.serviceAccountOpenIdTokenCreator` on the impersonation target, when `--gcp-impersonate-service-account` is used.
 
 ### Self-hosted Restate
 
-For self-hosted Restate calling private Cloud Run services, ensure one
-of the following:
+For self-hosted Restate calling private Cloud Run services, ensure one of the following:
 
-- The Restate process can reach Google's metadata server (typical on
-  GCE, GKE, or Cloud Run hosts), or
-- `GOOGLE_APPLICATION_CREDENTIALS` points to a service-account JSON key
-  file readable by the Restate user.
+- The Restate process can reach Google's metadata server (typical on GCE, GKE, or Cloud Run hosts), or
+- `GOOGLE_APPLICATION_CREDENTIALS` points to a service-account JSON key file readable by the Restate user.
 
-Restate does not contact any Google API or read any ADC source until the
-first deployment with native authentication enabled is observed.
+Restate does not contact any Google API or read any ADC source until the first deployment with native authentication enabled is observed.
 
 ### Local development
 
-For local development, run `gcloud auth application-default login` to
-populate ADC. This is distinct from `gcloud auth login`, which only
-populates user credentials for the `gcloud` tool itself.
+For local development, run `gcloud auth application-default login` to populate ADC. This is distinct from `gcloud auth login`, which only populates user credentials for the `gcloud` tool itself.
 
-Authorized-user ADC credentials cannot mint ID tokens for arbitrary
-audiences without impersonation, so pair them with
-`--gcp-impersonate-service-account` for the dev flow.
+Authorized-user ADC credentials cannot mint ID tokens for arbitrary audiences without impersonation, so pair them with `--gcp-impersonate-service-account` for the dev flow.
 
 ## Token caching and rotation
 
-Tokens are minted on demand and cached per
-`(impersonate_service_account, audience)` pair on the invoker. Cached
-tokens are evicted 60 seconds before expiry so that every outbound
-request carries a token with sufficient lifetime. Discovery requests do
-not cache tokens; a fresh token is minted for each discovery call,
-matching the existing Lambda assume-role behavior.
-
-## Comparison with Lambda authentication
-
-| | AWS Lambda | Google Cloud Run |
-|---|---|---|
-| Mechanism | STS `AssumeRole` | Google OIDC ID token |
-| Credential flag | `--assume-role-arn <ROLE_ARN>` | `--gcp-id-token` (optionally with `--gcp-impersonate-service-account` and `--gcp-audience`) |
-| Header sent to target | Signed AWS SigV4 invoke | `X-Serverless-Authorization: Bearer <token>` |
-| Target validation | Lambda invoke IAM | Cloud Run IAM (validates token, then strips header) |
-
-See the [AWS Lambda deployment guide](/services/deploy/lambda) for the
-parallel AWS flow.
+Tokens are minted on demand and cached per `(impersonate_service_account, audience)` pair on the invoker. Cached tokens are evicted 60 seconds before expiry so that every outbound request carries a token with sufficient lifetime. Discovery requests do not cache tokens; a fresh token is minted for each discovery call.

--- a/docs/services/deploy/kubernetes.mdx
+++ b/docs/services/deploy/kubernetes.mdx
@@ -72,7 +72,7 @@ The Restate Operator can help you connect your services to Restate Cloud by mana
 
 <Info>
     Try connecting your Kubernetes services to Restate Cloud by following this [guide](/guides/connecting-k8s-services-to-cloud).
-    Or check out the [Restate Cloud documentation](/cloud/connecting-services#connecting-kubernetes-services) for more information.
+    Or check out the [Restate Cloud documentation](/cloud/connecting-services#kubernetes-services) for more information.
 </Info>
 
 ### Automatic Service Versioning


### PR DESCRIPTION
Fixes #289.

Adds a new `services/deploy/cloud-run` page covering native Google OIDC ID-token authentication for HTTP deployments:

- What the feature is and when to use it (private Cloud Run services without long-lived bearer tokens in `additional_headers`).
- The three new `restate deployments register` flags: `--gcp-id-token`, `--gcp-impersonate-service-account`, `--gcp-audience`.
- Default audience derivation and when to override it (custom domains, traffic tags).
- How to update or remove auth via `--force` re-registration.
- ADC sources that can mint ID tokens ambiently vs. those that need impersonation, plus the required IAM roles (`roles/run.invoker`, `roles/iam.serviceAccountOpenIdTokenCreator`).
- Self-hosted credential discovery and local development guidance.
- Token caching behavior (per `(sa, audience)` on the invoker, evicted 60s before expiry; not cached on discovery).
- A short comparison table with the Lambda assume-role flow, with a cross-link to the Lambda deployment page.

Sourced from `release-notes/unreleased/4755-gcp-id-token-auth.md` in the runtime repo and the CLI flag definitions in `cli/src/commands/deployments/register.rs`. Added to the Deploy nav group between `lambda` and `cloudflare-workers`.