### PR TITLE
Document new /restate/ ingress endpoints (#288)

### DIFF
--- a/docs/ai-quickstart.mdx
+++ b/docs/ai-quickstart.mdx
@@ -74,7 +74,7 @@ Invoke the agent via the Restate UI playground: go to `http://localhost:9070`, c
 
 Or invoke via `curl`:
 ```shell
-curl localhost:8080/agent/run --json '{"prompt": "What is the weather in San Francisco?"}'
+curl localhost:8080/restate/call/agent/run --json '{"prompt": "What is the weather in San Francisco?"}'
 ```
 Output: `The weather in San Francisco is currently 23°C and sunny.`.
 </Step>
@@ -240,7 +240,7 @@ Invoke the agent via the Restate UI playground: go to `http://localhost:9070`, c
 
 Or invoke via `curl`:
 ```shell
-curl localhost:8080/agent/run --json '{"message": "What is the weather in San Francisco?"}'
+curl localhost:8080/restate/call/agent/run --json '{"message": "What is the weather in San Francisco?"}'
 ```
 Output: `The weather in San Francisco is sunny and 23°C.`
 
@@ -386,7 +386,7 @@ Invoke the agent via the Restate UI playground: go to `http://localhost:9070`, c
 
 Or invoke via `curl`:
 ```shell
-curl localhost:8080/agent/run --json '{
+curl localhost:8080/restate/call/agent/run --json '{
     "message": "What is the weather like in San Francisco?",
     "user_id": "user-123"
 }'
@@ -565,7 +565,7 @@ Invoke the agent via the Restate UI playground: go to `http://localhost:9070`, c
 
 Or invoke via `curl`:
 ```shell
-curl localhost:8080/agent/run --json '{"message": "What is the weather in San Francisco?"}'
+curl localhost:8080/restate/call/agent/run --json '{"message": "What is the weather in San Francisco?"}'
 ```
 Output: `The weather in San Francisco is sunny and 23°C.`
 
@@ -705,7 +705,7 @@ Invoke the agent via the Restate UI playground: go to `http://localhost:9070`, c
 
 Or invoke via `curl`:
 ```shell
-curl localhost:8080/agent/run --json '{"message": "What is the weather in San Francisco?"}'
+curl localhost:8080/restate/call/agent/run --json '{"message": "What is the weather in San Francisco?"}'
 ```
 Output: `The weather in San Francisco is sunny and 23°C.`
 
@@ -844,7 +844,7 @@ Invoke the agent via the Restate UI playground: go to `http://localhost:9070`, c
 
 Or invoke via `curl`:
 ```shell
-curl localhost:8080/agent/run --json '{"message": "What is the weather in San Francisco?"}'
+curl localhost:8080/restate/call/agent/run --json '{"message": "What is the weather in San Francisco?"}'
 ```
 Output: `The weather in San Francisco is currently 23°C and sunny.`
 </Step>
@@ -1026,7 +1026,7 @@ Invoke the agent via the Restate UI playground: go to `http://localhost:9070`, c
 
 Or invoke via `curl`:
 ```shell
-curl localhost:8080/agent/chat --json '{"message": "What is the weather in San Francisco?"}'
+curl localhost:8080/restate/call/agent/chat --json '{"message": "What is the weather in San Francisco?"}'
 ```
 Output: `The weather in San Francisco is currently 23°C and sunny.`
 </Step>

--- a/docs/ai/patterns/chat-ui-integration.mdx
+++ b/docs/ai/patterns/chat-ui-integration.mdx
@@ -162,7 +162,7 @@ const result = await fetch(`http://localhost:8080/restate/attach`, {
   method: "POST",
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify({
-    type: "idempotency",
+    target: "idempotentInvocation",
     service: "agent",
     handler: "run",
     idempotencyKey,

--- a/docs/ai/patterns/chat-ui-integration.mdx
+++ b/docs/ai/patterns/chat-ui-integration.mdx
@@ -91,15 +91,15 @@ You can also call Restate services using plain HTTP requests without the SDK.
 For example, in JavaScript:
 ```javascript {"CODE_LOAD::ts/src/ai/guides/chat-ui/http_requests.js#here"} 
 // Request-response
-const response = await fetch("http://localhost:8080/my-agent/run", {
+const response = await fetch("http://localhost:8080/restate/call/my-agent/run", {
   method: "POST",
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify({ message: "How are you?" }),
 });
 const result = await response.json();
 
-// Fire-and-forget: add /send to the URL
-await fetch("http://localhost:8080/my-agent/run/send", {
+// Fire-and-forget: use the /restate/send/... path
+await fetch("http://localhost:8080/restate/send/my-agent/run", {
   method: "POST",
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify({ message: "How are you?" }),
@@ -113,7 +113,7 @@ await fetch("http://localhost:8080/my-agent/run/send", {
 You can let Restate deduplicate requests by adding an idempotency key to the header of your request.
 
 ```javascript {"CODE_LOAD::ts/src/ai/guides/chat-ui/http_requests.js#idempotency"} 
-await fetch("http://localhost:8080/my-agent/run/send", {
+await fetch("http://localhost:8080/restate/send/my-agent/run", {
   method: "POST",
   headers: {
     "Content-Type": "application/json",
@@ -136,7 +136,7 @@ There are three ways to do this:
 
 ```javascript {"CODE_LOAD::ts/src/ai/guides/chat-ui/http_requests.js#attach"} 
 // start the invocation
-const handle = await fetch("http://localhost:8080/agent/run/send", {
+const handle = await fetch("http://localhost:8080/restate/send/agent/run", {
   method: "POST",
   headers: { "Content-Type": "application/json" },
   body: JSON.stringify("How are you?"),
@@ -145,9 +145,9 @@ const handle = await fetch("http://localhost:8080/agent/run/send", {
 // retrieve the invocationId
 const { invocationId, status } = await handle.json();
 
-// retrieve the result
+// retrieve the result by attaching to the invocation id
 const result = await fetch(
-  `http://localhost:8080/restate/invocation/${invocationId}/attach`,
+  `http://localhost:8080/restate/attach/${invocationId}`,
   { method: "GET" }
 );
 await result.json();
@@ -156,12 +156,18 @@ await result.json();
 3. If you started the invocation with an idempotency key, then you can use that to attach to it. This does not start the invocation as opposed to point 1:
 
 ```javascript {"CODE_LOAD::ts/src/ai/guides/chat-ui/http_requests.js#attach_idem"} 
-// start the invocation with idempotency key
+// attach via the idempotency key of an earlier invocation
 const idempotencyKey = "abc-123";
-const result = await fetch(
-  `http://localhost:8080/restate/invocation/agent/run/${idempotencyKey}/attach`,
-  { method: "GET" }
-);
+const result = await fetch(`http://localhost:8080/restate/attach`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    type: "idempotency",
+    service: "agent",
+    handler: "run",
+    idempotencyKey,
+  }),
+});
 await result.json();
 ```
 

--- a/docs/ai/patterns/competitive-racing.mdx
+++ b/docs/ai/patterns/competitive-racing.mdx
@@ -81,7 +81,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/RacingAgent/run \
+curl localhost:8080/restate/call/RacingAgent/run \
 --json '{
     "message": "What is the best approach to learn machine learning?"
 }'
@@ -126,7 +126,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/RacingAgent/run \
+curl localhost:8080/restate/call/RacingAgent/run \
 --json '{
     "message": "What is the best approach to learn machine learning?"
 }'

--- a/docs/ai/patterns/human-in-the-loop.mdx
+++ b/docs/ai/patterns/human-in-the-loop.mdx
@@ -88,9 +88,9 @@ Register the agents with Restate:
 restate deployments register http://localhost:9080 --force --yes # dev only: overrides previous registrations
 ```
 
-Use `curl` with `/send` to start the claim asynchronously, without waiting for the result:
+Use `curl` with the `send` verb to start the claim asynchronously, without waiting for the result:
 ```bash
-curl localhost:8080/HumanClaimApprovalAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalAgent/run \
 --json '{"prompt": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 
@@ -145,9 +145,9 @@ Register the agents with Restate:
 restate deployments register http://localhost:9080 --force --yes # dev only: overrides previous registrations
 ```
 
-Use `curl` with `/send` to start the claim asynchronously, without waiting for the result:
+Use `curl` with the `send` verb to start the claim asynchronously, without waiting for the result:
 ```bash
-curl localhost:8080/HumanClaimApprovalAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalAgent/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 
@@ -203,9 +203,9 @@ Register the agents with Restate:
 restate deployments register http://localhost:9080 --force --yes # dev only: overrides previous registrations
 ```
 
-Use `curl` with `/send` to start the claim asynchronously, without waiting for the result:
+Use `curl` with the `send` verb to start the claim asynchronously, without waiting for the result:
 ```bash
-curl localhost:8080/HumanClaimApprovalAgent/user-123/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalAgent/user-123/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg.", "session_id": "session-123"}'
 ```
 
@@ -260,9 +260,9 @@ Register the agents with Restate:
 restate deployments register http://localhost:9080 --force --yes # dev only: overrides previous registrations
 ```
 
-Use `curl` with `/send` to start the claim asynchronously, without waiting for the result:
+Use `curl` with the `send` verb to start the claim asynchronously, without waiting for the result:
 ```bash
-curl localhost:8080/HumanClaimApprovalAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalAgent/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 
@@ -317,9 +317,9 @@ Register the agents with Restate:
 restate deployments register http://localhost:9080 --force --yes # dev only: overrides previous registrations
 ```
 
-Use `curl` with `/send` to start the claim asynchronously, without waiting for the result:
+Use `curl` with the `send` verb to start the claim asynchronously, without waiting for the result:
 ```bash
-curl localhost:8080/HumanClaimApprovalAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalAgent/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 
@@ -388,9 +388,9 @@ Register the services with Restate:
 restate deployments register http://localhost:9080 --force --yes # dev only: overrides previous registrations
 ```
 
-Use `curl` with `/send` to start the moderation asynchronously:
+Use `curl` with the `send` verb to start the moderation asynchronously:
 ```bash
-curl localhost:8080/HumanClaimApprovalAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalAgent/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 
@@ -475,9 +475,9 @@ Register the services with Restate:
 restate deployments register http://localhost:9080 --force --yes # dev only: overrides previous registrations
 ```
 
-Use `curl` with `/send` to start the claim asynchronously, without waiting for the result:
+Use `curl` with the `send` verb to start the claim asynchronously, without waiting for the result:
 ```bash
-curl localhost:8080/HumanClaimApprovalAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalAgent/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 
@@ -543,7 +543,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request to the service:
 ```bash
-curl localhost:8080/HumanClaimApprovalWithTimeoutsAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalWithTimeoutsAgent/run \
 --json '{"prompt": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 Restart the service and check in the UI how the process will block for the remaining time without starting over.
@@ -591,7 +591,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request to the service:
 ```bash
-curl localhost:8080/HumanClaimApprovalWithTimeoutsAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalWithTimeoutsAgent/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 Restart the service and check in the UI how the process will block for the remaining time without starting over.
@@ -641,7 +641,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request to the service:
 ```bash
-curl localhost:8080/HumanClaimApprovalWithTimeoutsAgent/user-123/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalWithTimeoutsAgent/user-123/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg.", "session_id": "session-123"}'
 ```
 Restart the service and check in the UI how the process will block for the remaining time without starting over.
@@ -693,7 +693,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request to the service:
 ```bash
-curl localhost:8080/HumanClaimApprovalWithTimeoutsAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalWithTimeoutsAgent/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 Restart the service and check in the UI how the process will block for the remaining time without starting over.
@@ -741,7 +741,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request to the service:
 ```bash
-curl localhost:8080/HumanClaimApprovalWithTimeoutsAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalWithTimeoutsAgent/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 Restart the service and check in the UI how the process will block for the remaining time without starting over.
@@ -784,7 +784,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request to the service:
 ```bash
-curl localhost:8080/HumanClaimApprovalWithTimeoutsAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalWithTimeoutsAgent/run \
 --json '{"prompt": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 Restart the service and check in the UI how the process will block for the remaining time without starting over.
@@ -832,7 +832,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request to the service:
 ```bash
-curl localhost:8080/HumanClaimApprovalWithTimeoutsAgent/run/send \
+curl localhost:8080/restate/send/HumanClaimApprovalWithTimeoutsAgent/run \
 --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 Restart the service and check in the UI how the process will block for the remaining time without starting over.

--- a/docs/ai/patterns/interrupt-regenerate.mdx
+++ b/docs/ai/patterns/interrupt-regenerate.mdx
@@ -160,24 +160,24 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 **Happy path** — one message, one full response:
 ```bash
-curl localhost:8080/CodingAgent/alice/message \
+curl localhost:8080/restate/call/CodingAgent/alice/message \
   --json '{"content":"Write me a small todo CLI in TypeScript."}'
 
 # Wait a few seconds, then:
-curl localhost:8080/CodingAgent/alice/getHistory
+curl localhost:8080/restate/call/CodingAgent/alice/getHistory
 ```
 
 **Interruption path** — fire a first message, then interrupt before it finishes:
 ```bash
 # Fire-and-forget the first message
-curl localhost:8080/CodingAgent/bob/message/send \
+curl localhost:8080/restate/send/CodingAgent/bob/message \
   --json '{"content":"Build a Fastify app with user auth."}'
 
 # Immediately interrupt with new context
-curl localhost:8080/CodingAgent/bob/message \
+curl localhost:8080/restate/call/CodingAgent/bob/message \
   --json '{"content":"Actually, use Hono instead of Fastify."}'
 
-curl localhost:8080/CodingAgent/bob/getHistory
+curl localhost:8080/restate/call/CodingAgent/bob/getHistory
 ```
 
 Open the Restate UI at `http://localhost:9070` to inspect the invocations — the first `CodingTask.runTask` shows status `cancelled`, and the second `completed`.
@@ -296,24 +296,24 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 **Happy path**: one message, one full response:
 ```bash
-curl localhost:8080/CodingAgent/alice/message \
+curl localhost:8080/restate/call/CodingAgent/alice/message \
   --json '{"content":"Write me a small todo CLI in Python."}'
 
 # Wait a few seconds, then:
-curl localhost:8080/CodingAgent/alice/get_history
+curl localhost:8080/restate/call/CodingAgent/alice/get_history
 ```
 
 **Interruption path**: fire a first message, then interrupt before it finishes:
 ```bash
 # Fire-and-forget the first message
-curl localhost:8080/CodingAgent/bob/message/send \
+curl localhost:8080/restate/send/CodingAgent/bob/message \
   --json '{"content":"Build a Flask app with user auth."}'
 
 # Immediately interrupt with new context
-curl localhost:8080/CodingAgent/bob/message \
+curl localhost:8080/restate/call/CodingAgent/bob/message \
   --json '{"content":"Actually, use FastAPI instead of Flask."}'
 
-curl localhost:8080/CodingAgent/bob/get_history
+curl localhost:8080/restate/call/CodingAgent/bob/get_history
 ```
 
 Open the Restate UI at `http://localhost:9070` to inspect the invocations — the first `CodingTask.run_task` shows status `cancelled`, and the second `completed`.

--- a/docs/ai/patterns/multi-agent.mdx
+++ b/docs/ai/patterns/multi-agent.mdx
@@ -113,7 +113,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents:
 ```bash
-curl localhost:8080/MultiAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/MultiAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -190,7 +190,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents:
 ```bash
-curl localhost:8080/MultiAgentClaimApproval/session123/run --json '{
+curl localhost:8080/restate/call/MultiAgentClaimApproval/session123/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -276,7 +276,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents:
 ```bash
-curl localhost:8080/MultiAgentClaimApproval/user123/run --json '{
+curl localhost:8080/restate/call/MultiAgentClaimApproval/user123/run --json '{
     "amount": 3000,
     "category": "orthopedic",
     "date": "2024-10-01",
@@ -361,7 +361,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents:
 ```bash
-curl localhost:8080/MultiAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/MultiAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -456,7 +456,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents:
 ```bash
-curl localhost:8080/MultiAgentClaimApproval/session123/run --json '{
+curl localhost:8080/restate/call/MultiAgentClaimApproval/session123/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -542,7 +542,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/AgentRouter/answer \
+curl localhost:8080/restate/call/AgentRouter/answer \
   --json '{"message": "I was charged twice for my subscription last month"}'
 ```
 </Accordion>
@@ -612,7 +612,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/AgentRouter/answer \
+curl localhost:8080/restate/call/AgentRouter/answer \
   --json '{"message": "I was charged twice for my subscription last month"}'
 ```
 </Accordion>

--- a/docs/ai/patterns/notify-when-ready.mdx
+++ b/docs/ai/patterns/notify-when-ready.mdx
@@ -135,17 +135,17 @@ If you need help with a specific SDK, please reach out to us via [Discord](https
 
     Or send requests via the terminal.
 
-    First, start the agent asynchronously by adding `/send` to the end of the URL:
+    First, start the agent asynchronously by using the `send` verb:
 
     ```shell
-    curl localhost:8080/AsyncNotificationsAgent/msg-123/run/send \
+    curl localhost:8080/restate/send/AsyncNotificationsAgent/msg-123/run \
       --json '"Write a 1000-word description of Durable Execution"'
     ```
 
     Then, asynchronously call the `on_notify` handler to send the agent response via email once it's ready:
 
     ```shell
-    curl localhost:8080/AsyncNotificationsAgent/msg-123/on_notify/send \
+    curl localhost:8080/restate/send/AsyncNotificationsAgent/msg-123/on_notify \
       --json '"me@mail.com"'
     ```
 

--- a/docs/ai/patterns/parallelization.mdx
+++ b/docs/ai/patterns/parallelization.mdx
@@ -94,7 +94,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request:
 ```bash
-curl localhost:8080/ParallelToolClaimAgent/run --json '{
+curl localhost:8080/restate/call/ParallelToolClaimAgent/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -147,7 +147,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request:
 ```bash
-curl localhost:8080/ParallelToolClaimAgent/run --json '{
+curl localhost:8080/restate/call/ParallelToolClaimAgent/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -199,7 +199,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request:
 ```bash
-curl localhost:8080/ParallelToolClaimAgent/user123/run --json '{
+curl localhost:8080/restate/call/ParallelToolClaimAgent/user123/run --json '{
     "amount": 3000,
     "category": "orthopedic",
     "date": "2024-10-01",
@@ -255,7 +255,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request:
 ```bash
-curl localhost:8080/ParallelToolClaimAgent/run --json '{
+curl localhost:8080/restate/call/ParallelToolClaimAgent/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -308,7 +308,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request:
 ```bash
-curl localhost:8080/ParallelToolClaimAgent/run --json '{
+curl localhost:8080/restate/call/ParallelToolClaimAgent/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -395,7 +395,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ParallelToolAgent/run \
+curl localhost:8080/restate/call/ParallelToolAgent/run \
   --json '{"message": "What is the weather in San Francisco and New York?"}'
 ```
 </Accordion>
@@ -464,7 +464,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ParallelToolAgent/run \
+curl localhost:8080/restate/call/ParallelToolAgent/run \
   --json '{"message": "What is the weather in San Francisco and New York?"}'
 ```
 </Accordion>

--- a/docs/ai/patterns/remote-agents.mdx
+++ b/docs/ai/patterns/remote-agents.mdx
@@ -125,7 +125,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents:
 ```bash
-curl localhost:8080/MultiAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/MultiAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -209,7 +209,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents:
 ```bash
-curl localhost:8080/MultiAgentClaimApproval/session123/run --json '{
+curl localhost:8080/restate/call/MultiAgentClaimApproval/session123/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -305,7 +305,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents:
 ```bash
-curl localhost:8080/MultiAgentClaimApproval/user123/run --json '{
+curl localhost:8080/restate/call/MultiAgentClaimApproval/user123/run --json '{
     "amount": 3000,
     "category": "orthopedic",
     "date": "2024-10-01",
@@ -385,7 +385,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents:
 ```bash
-curl localhost:8080/MultiAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/MultiAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -453,7 +453,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents:
 ```bash
-curl localhost:8080/MultiAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/MultiAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -556,7 +556,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/RemoteAgentRouter/answer \
+curl localhost:8080/restate/call/RemoteAgentRouter/answer \
 --json '{"message": "I was charged twice for my subscription last month"}'
 ```
 </Accordion>
@@ -645,7 +645,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/RemoteAgentRouter/answer \
+curl localhost:8080/restate/call/RemoteAgentRouter/answer \
 --json '{"message": "I was charged twice for my subscription last month"}'
 ```
 </Accordion>

--- a/docs/ai/patterns/sessions.mdx
+++ b/docs/ai/patterns/sessions.mdx
@@ -95,19 +95,19 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Ask the agent to do some task. Specify the Virtual Object ID in the URL, for example for `session123`:
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "make a poem about durable execution"}'
 ```
 
 Continue the conversation with the same session ID. The agent remembers previous context:
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "shorten it to 2 lines"}'
 ```
 
 Send a message to a different session. It starts a completely separate conversation:
 ```bash
-curl localhost:8080/Chat/session456/message \
+curl localhost:8080/restate/call/Chat/session456/message \
 --json '{"message": "what are the benefits of durable execution?"}'
 ```
 </Accordion>
@@ -154,13 +154,13 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Ask the agent to do some task. Specify the Virtual Object ID in the URL, for example for `session123`:
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "Make a poem about durable execution."}'
 ```
 
 Continue the conversation with the same session ID. The agent remembers previous context:
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "Shorten it to 2 lines."}'
 ```
 
@@ -168,7 +168,7 @@ Go to the state tab of the UI to view the conversation history.
 
 Send a message to a different session. It starts a completely separate conversation:
 ```bash
-curl localhost:8080/Chat/session456/message \
+curl localhost:8080/restate/call/Chat/session456/message \
 --json '{"message": "What are the benefits of durable execution?"}'
 ```
 </Accordion>
@@ -221,13 +221,13 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Ask the agent to do some task. Specify the Virtual Object ID in the URL, for example for `session123`:
 ```bash
-curl localhost:8080/Chat/user123/message \
+curl localhost:8080/restate/call/Chat/user123/message \
 --json '{"message": "Make a poem about durable execution.", "session_id": "session-123"}'
 ```
 
 Continue the conversation with the same user and session ID. The agent remembers previous context:
 ```bash
-curl localhost:8080/Chat/user123/message \
+curl localhost:8080/restate/call/Chat/user123/message \
 --json '{"message": "Shorten it to 2 lines.", "session_id": "session-123"}'
 ```
 
@@ -235,7 +235,7 @@ Go to the state tab of the UI to view the conversation history.
 
 Send a message to a different user. It starts a completely separate conversation:
 ```bash
-curl localhost:8080/Chat/user456/message \
+curl localhost:8080/restate/call/Chat/user456/message \
 --json '{"message": "What are the benefits of durable execution?", "session_id": "session-567"}'
 ```
 </Accordion>
@@ -288,13 +288,13 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Ask the agent to do some task. Specify the Virtual Object ID in the URL, for example for `session123`:
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "Make a poem about durable execution."}'
 ```
 
 Continue the conversation with the same session ID. The agent remembers previous context:
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "Shorten it to 2 lines."}'
 ```
 
@@ -302,7 +302,7 @@ Go to the state tab of the UI to view the conversation history.
 
 Send a message to a different session. It starts a completely separate conversation:
 ```bash
-curl localhost:8080/Chat/session456/message \
+curl localhost:8080/restate/call/Chat/session456/message \
 --json '{"message": "What are the benefits of durable execution?"}'
 ```
 </Accordion>
@@ -354,13 +354,13 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Ask the agent to do some task. Specify the Virtual Object ID in the URL, for example for `session123`:
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "Make a poem about durable execution."}'
 ```
 
 Continue the conversation with the same session ID. The agent remembers previous context:
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "Shorten it to 2 lines."}'
 ```
 
@@ -368,7 +368,7 @@ Go to the state tab of the UI to view the conversation history.
 
 Send a message to a different session. It starts a completely separate conversation:
 ```bash
-curl localhost:8080/Chat/session456/message \
+curl localhost:8080/restate/call/Chat/session456/message \
 --json '{"message": "What are the benefits of durable execution?"}'
 ```
 </Accordion>
@@ -436,19 +436,19 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 Ask the agent to do some task. Specify the Virtual Object ID in the URL, for example for `session123`:
 
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "make a poem about durable execution"}'
 ```
 
 Continue the conversation with the same session ID. The agent remembers previous context:
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "shorten it to 2 lines"}'
 ```
 
 Send a message to a different session. It starts a completely separate conversation:
 ```bash
-curl localhost:8080/Chat/session456/message \
+curl localhost:8080/restate/call/Chat/session456/message \
 --json '{"message": "what are the benefits of durable execution?"}'
 ```
 </Accordion>
@@ -506,19 +506,19 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 Ask the agent to do some task. Specify the Virtual Object ID in the URL, for example for `session123`:
 
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "make a poem about durable execution"}'
 ```
 
 Continue the conversation with the same session ID. The agent remembers previous context:
 ```bash
-curl localhost:8080/Chat/session123/message \
+curl localhost:8080/restate/call/Chat/session123/message \
 --json '{"message": "shorten it to 2 lines"}'
 ```
 
 Send a message to a different session. It starts a completely separate conversation:
 ```bash
-curl localhost:8080/Chat/session456/message \
+curl localhost:8080/restate/call/Chat/session456/message \
 --json '{"message": "what are the benefits of durable execution?"}'
 ```
 </Accordion>
@@ -588,14 +588,14 @@ Different session keys run in parallel with no interference.
 <Accordion title="Try out queuing" icon="laptop">
 Send several messages concurrently to different chat sessions:
 ```bash
-curl localhost:8080/Chat/session123/message/send --json '{"message": "make a poem about durable execution"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what are the benefits of durable execution?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "how does workflow orchestration work?"}' &
-curl localhost:8080/Chat/session123/message/send --json '{"message": "can you make it rhyme better?"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what about fault tolerance in distributed systems?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "give me a practical example"}' &
-curl localhost:8080/Chat/session101/message/send --json '{"message": "explain event sourcing in simple terms"}' &
-curl localhost:8080/Chat/session202/message/send --json '{"message": "what is the difference between async and sync processing?"}'
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "make a poem about durable execution"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what are the benefits of durable execution?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "how does workflow orchestration work?"}' &
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "can you make it rhyme better?"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what about fault tolerance in distributed systems?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "give me a practical example"}' &
+curl localhost:8080/restate/send/Chat/session101/message --json '{"message": "explain event sourcing in simple terms"}' &
+curl localhost:8080/restate/send/Chat/session202/message --json '{"message": "what is the difference between async and sync processing?"}'
 ```
 
 The UI shows how Restate queues the requests per session to ensure consistency:
@@ -608,14 +608,14 @@ The UI shows how Restate queues the requests per session to ensure consistency:
 <Accordion title="Try out queuing" icon="laptop">
 Send several messages concurrently to different chat sessions:
 ```bash
-curl localhost:8080/Chat/session123/message/send --json '{"message": "make a poem about durable execution"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what are the benefits of durable execution?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "how does workflow orchestration work?"}' &
-curl localhost:8080/Chat/session123/message/send --json '{"message": "can you make it rhyme better?"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what about fault tolerance in distributed systems?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "give me a practical example"}' &
-curl localhost:8080/Chat/session101/message/send --json '{"message": "explain event sourcing in simple terms"}' &
-curl localhost:8080/Chat/session202/message/send --json '{"message": "what is the difference between async and sync processing?"}'
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "make a poem about durable execution"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what are the benefits of durable execution?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "how does workflow orchestration work?"}' &
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "can you make it rhyme better?"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what about fault tolerance in distributed systems?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "give me a practical example"}' &
+curl localhost:8080/restate/send/Chat/session101/message --json '{"message": "explain event sourcing in simple terms"}' &
+curl localhost:8080/restate/send/Chat/session202/message --json '{"message": "what is the difference between async and sync processing?"}'
 ```
 
 The UI shows how Restate queues the requests per session to ensure consistency:
@@ -628,14 +628,14 @@ The UI shows how Restate queues the requests per session to ensure consistency:
 <Accordion title="Try out queuing" icon="laptop">
 Send several messages concurrently to different users:
 ```bash
-curl localhost:8080/Chat/user123/message/send --json '{"message": "make a poem about durable execution", "session_id": "session-123"}' &
-curl localhost:8080/Chat/user456/message/send --json '{"message": "what are the benefits of durable execution?", "session_id": "session-567"}' &
-curl localhost:8080/Chat/user789/message/send --json '{"message": "how does workflow orchestration work?", "session_id": "session-999"}' &
-curl localhost:8080/Chat/user123/message/send --json '{"message": "can you make it rhyme better?", "session_id": "session-123"}' &
-curl localhost:8080/Chat/user456/message/send --json '{"message": "what about fault tolerance in distributed systems?", "session_id": "session-567"}' &
-curl localhost:8080/Chat/user789/message/send --json '{"message": "give me a practical example", "session_id": "session-999"}' &
-curl localhost:8080/Chat/user101/message/send --json '{"message": "explain event sourcing in simple terms", "session_id": "session-123"}' &
-curl localhost:8080/Chat/user202/message/send --json '{"message": "what is the difference between async and sync processing?", "session_id": "session-123"}'
+curl localhost:8080/restate/send/Chat/user123/message --json '{"message": "make a poem about durable execution", "session_id": "session-123"}' &
+curl localhost:8080/restate/send/Chat/user456/message --json '{"message": "what are the benefits of durable execution?", "session_id": "session-567"}' &
+curl localhost:8080/restate/send/Chat/user789/message --json '{"message": "how does workflow orchestration work?", "session_id": "session-999"}' &
+curl localhost:8080/restate/send/Chat/user123/message --json '{"message": "can you make it rhyme better?", "session_id": "session-123"}' &
+curl localhost:8080/restate/send/Chat/user456/message --json '{"message": "what about fault tolerance in distributed systems?", "session_id": "session-567"}' &
+curl localhost:8080/restate/send/Chat/user789/message --json '{"message": "give me a practical example", "session_id": "session-999"}' &
+curl localhost:8080/restate/send/Chat/user101/message --json '{"message": "explain event sourcing in simple terms", "session_id": "session-123"}' &
+curl localhost:8080/restate/send/Chat/user202/message --json '{"message": "what is the difference between async and sync processing?", "session_id": "session-123"}'
 ```
 
 The UI shows how Restate queues the requests per session to ensure consistency:
@@ -648,14 +648,14 @@ The UI shows how Restate queues the requests per session to ensure consistency:
 <Accordion title="Try out queuing" icon="laptop">
 Send several messages concurrently to different chat sessions:
 ```bash
-curl localhost:8080/Chat/session123/message/send --json '{"message": "make a poem about durable execution"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what are the benefits of durable execution?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "how does workflow orchestration work?"}' &
-curl localhost:8080/Chat/session123/message/send --json '{"message": "can you make it rhyme better?"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what about fault tolerance in distributed systems?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "give me a practical example"}' &
-curl localhost:8080/Chat/session101/message/send --json '{"message": "explain event sourcing in simple terms"}' &
-curl localhost:8080/Chat/session202/message/send --json '{"message": "what is the difference between async and sync processing?"}'
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "make a poem about durable execution"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what are the benefits of durable execution?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "how does workflow orchestration work?"}' &
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "can you make it rhyme better?"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what about fault tolerance in distributed systems?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "give me a practical example"}' &
+curl localhost:8080/restate/send/Chat/session101/message --json '{"message": "explain event sourcing in simple terms"}' &
+curl localhost:8080/restate/send/Chat/session202/message --json '{"message": "what is the difference between async and sync processing?"}'
 ```
 
 The UI shows how Restate queues the requests per session to ensure consistency:
@@ -668,14 +668,14 @@ The UI shows how Restate queues the requests per session to ensure consistency:
 <Accordion title="Try out queuing" icon="laptop">
 Send several messages concurrently to different chat sessions:
 ```bash
-curl localhost:8080/Chat/session123/message/send --json '{"message": "make a poem about durable execution"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what are the benefits of durable execution?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "how does workflow orchestration work?"}' &
-curl localhost:8080/Chat/session123/message/send --json '{"message": "can you make it rhyme better?"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what about fault tolerance in distributed systems?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "give me a practical example"}' &
-curl localhost:8080/Chat/session101/message/send --json '{"message": "explain event sourcing in simple terms"}' &
-curl localhost:8080/Chat/session202/message/send --json '{"message": "what is the difference between async and sync processing?"}'
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "make a poem about durable execution"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what are the benefits of durable execution?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "how does workflow orchestration work?"}' &
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "can you make it rhyme better?"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what about fault tolerance in distributed systems?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "give me a practical example"}' &
+curl localhost:8080/restate/send/Chat/session101/message --json '{"message": "explain event sourcing in simple terms"}' &
+curl localhost:8080/restate/send/Chat/session202/message --json '{"message": "what is the difference between async and sync processing?"}'
 ```
 
 The UI shows how Restate queues the requests per session to ensure consistency:
@@ -688,14 +688,14 @@ The UI shows how Restate queues the requests per session to ensure consistency:
 <Accordion title="Try out queuing" icon="laptop">
 Send several messages concurrently to different chat sessions:
 ```bash
-curl localhost:8080/Chat/session123/message/send --json '{"message": "make a poem about durable execution"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what are the benefits of durable execution?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "how does workflow orchestration work?"}' &
-curl localhost:8080/Chat/session123/message/send --json '{"message": "can you make it rhyme better?"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what about fault tolerance in distributed systems?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "give me a practical example"}' &
-curl localhost:8080/Chat/session101/message/send --json '{"message": "explain event sourcing in simple terms"}' &
-curl localhost:8080/Chat/session202/message/send --json '{"message": "what is the difference between async and sync processing?"}'
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "make a poem about durable execution"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what are the benefits of durable execution?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "how does workflow orchestration work?"}' &
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "can you make it rhyme better?"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what about fault tolerance in distributed systems?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "give me a practical example"}' &
+curl localhost:8080/restate/send/Chat/session101/message --json '{"message": "explain event sourcing in simple terms"}' &
+curl localhost:8080/restate/send/Chat/session202/message --json '{"message": "what is the difference between async and sync processing?"}'
 ```
 
 The UI shows how Restate queues the requests per session to ensure consistency:
@@ -708,14 +708,14 @@ The UI shows how Restate queues the requests per session to ensure consistency:
 <Accordion title="Try out queuing" icon="laptop">
 Send several messages concurrently to different chat sessions:
 ```bash
-curl localhost:8080/Chat/session123/message/send --json '{"message": "make a poem about durable execution"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what are the benefits of durable execution?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "how does workflow orchestration work?"}' &
-curl localhost:8080/Chat/session123/message/send --json '{"message": "can you make it rhyme better?"}' &
-curl localhost:8080/Chat/session456/message/send --json '{"message": "what about fault tolerance in distributed systems?"}' &
-curl localhost:8080/Chat/session789/message/send --json '{"message": "give me a practical example"}' &
-curl localhost:8080/Chat/session101/message/send --json '{"message": "explain event sourcing in simple terms"}' &
-curl localhost:8080/Chat/session202/message/send --json '{"message": "what is the difference between async and sync processing?"}'
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "make a poem about durable execution"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what are the benefits of durable execution?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "how does workflow orchestration work?"}' &
+curl localhost:8080/restate/send/Chat/session123/message --json '{"message": "can you make it rhyme better?"}' &
+curl localhost:8080/restate/send/Chat/session456/message --json '{"message": "what about fault tolerance in distributed systems?"}' &
+curl localhost:8080/restate/send/Chat/session789/message --json '{"message": "give me a practical example"}' &
+curl localhost:8080/restate/send/Chat/session101/message --json '{"message": "explain event sourcing in simple terms"}' &
+curl localhost:8080/restate/send/Chat/session202/message --json '{"message": "what is the difference between async and sync processing?"}'
 ```
 
 The UI shows how Restate queues the requests per session to ensure consistency:
@@ -738,7 +738,7 @@ To retrieve state, view the UI's state tab or add a handler that reads it. Have 
 Call the handler to get the conversation history:
 
 ```bash
-curl localhost:8080/Chat/session123/getHistory
+curl localhost:8080/restate/call/Chat/session123/getHistory
 ```
 
 </GlobalTab>
@@ -749,7 +749,7 @@ To retrieve state, view the UI's state tab or add a handler that reads it. Have 
 Call the handler to get the conversation history:
 
 ```bash
-curl localhost:8080/Chat/session123/get_history
+curl localhost:8080/restate/call/Chat/session123/get_history
 ```
 
 </GlobalTab>
@@ -759,7 +759,7 @@ To retrieve state, view the UI's state tab or add a handler that reads it. Have 
 Call the handler to get the conversation history:
 
 ```bash
-curl localhost:8080/Chat/user123/get_history --json '"session-123"'
+curl localhost:8080/restate/call/Chat/user123/get_history --json '"session-123"'
 ```
 
 </GlobalTab>
@@ -770,7 +770,7 @@ To retrieve state, view the UI's state tab or add a handler that reads it. Have 
 Call the handler to get the conversation history:
 
 ```bash
-curl localhost:8080/Chat/session123/get_history
+curl localhost:8080/restate/call/Chat/session123/get_history
 ```
 
 </GlobalTab>
@@ -781,7 +781,7 @@ To retrieve state, view the UI's state tab or add a handler that reads it. Have 
 Call the handler to get the conversation history:
 
 ```bash
-curl localhost:8080/Chat/session123/get_history
+curl localhost:8080/restate/call/Chat/session123/get_history
 ```
 
 </GlobalTab>
@@ -792,7 +792,7 @@ To retrieve state, view the UI's state tab or add a handler that reads it. Have 
 Call the handler to get the conversation history:
 
 ```bash
-curl localhost:8080/Chat/session123/getHistory
+curl localhost:8080/restate/call/Chat/session123/getHistory
 ```
 
 </GlobalTab>
@@ -803,7 +803,7 @@ To retrieve state, view the UI's state tab or add as handler that reads it. Have
 Call the handler to get the conversation history:
 
 ```bash
-curl localhost:8080/Chat/session123/get_history
+curl localhost:8080/restate/call/Chat/session123/get_history
 ```
 
 </GlobalTab>

--- a/docs/ai/patterns/tools.mdx
+++ b/docs/ai/patterns/tools.mdx
@@ -191,7 +191,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request that triggers the human approval sub-workflow:
 ```bash
-curl localhost:8080/SubWorkflowClaimAgent/run/send \
+curl localhost:8080/restate/send/SubWorkflowClaimAgent/run \
   --json '{"prompt": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 
@@ -231,7 +231,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request that triggers the human approval sub-workflow:
 ```bash
-curl localhost:8080/SubWorkflowClaimAgent/run/send \
+curl localhost:8080/restate/send/SubWorkflowClaimAgent/run \
   --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 
@@ -266,7 +266,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request that triggers the human approval sub-workflow:
 ```bash
-curl localhost:8080/SubWorkflowClaimAgent/user-123/run/send \
+curl localhost:8080/restate/send/SubWorkflowClaimAgent/user-123/run \
   --json '{"message": "Process my hospital bill of 3000USD for a broken leg.", "session_id": "session-123"}'
 ```
 
@@ -302,7 +302,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request that triggers the human approval sub-workflow:
 ```bash
-curl localhost:8080/SubWorkflowClaimAgent/run/send \
+curl localhost:8080/restate/send/SubWorkflowClaimAgent/run \
   --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 
@@ -338,7 +338,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request that triggers the human approval sub-workflow:
 ```bash
-curl localhost:8080/SubWorkflowClaimAgent/run/send \
+curl localhost:8080/restate/send/SubWorkflowClaimAgent/run \
   --json '{"message": "Process my hospital bill of 3000USD for a broken leg."}'
 ```
 

--- a/docs/ai/patterns/workflow-evaluator.mdx
+++ b/docs/ai/patterns/workflow-evaluator.mdx
@@ -107,7 +107,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Sends a request to the agent:
 ```shell
-curl localhost:8080/CodeGenerator/generate \
+curl localhost:8080/restate/call/CodeGenerator/generate \
 --json '{
     "task": "Write a TypeScript function that implements a retry mechanism with exponential backoff"
 }'
@@ -176,7 +176,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/CodeGenerator/generate \
+curl localhost:8080/restate/call/CodeGenerator/generate \
   --json '{"task": "Write a function that checks if a string is a palindrome"}'
 ```
 </Accordion>
@@ -258,7 +258,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/CodeGenerator/user123/generate \
+curl localhost:8080/restate/call/CodeGenerator/user123/generate \
   --json '{"task": "Write a function that checks if a string is a palindrome"}'
 ```
 </Accordion>
@@ -325,7 +325,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/CodeGenerator/generate \
+curl localhost:8080/restate/call/CodeGenerator/generate \
   --json '{"task": "Write a function that checks if a string is a palindrome"}'
 ```
 </Accordion>
@@ -396,7 +396,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/CodeGenerator/generate \
+curl localhost:8080/restate/call/CodeGenerator/generate \
   --json '{"task": "Write a function that checks if a string is a palindrome"}'
 ```
 </Accordion>
@@ -470,7 +470,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/CodeGenerator/generate \
+curl localhost:8080/restate/call/CodeGenerator/generate \
   --json '{"task": "Write a function that checks if a string is a palindrome"}'
 ```
 </Accordion>
@@ -534,7 +534,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/CodeGenerator/generate \
+curl localhost:8080/restate/call/CodeGenerator/generate \
   --json '{"task": "Write a function that checks if a string is a palindrome"}'
 ```
 </Accordion>

--- a/docs/ai/patterns/workflow-orchestrator.mdx
+++ b/docs/ai/patterns/workflow-orchestrator.mdx
@@ -122,7 +122,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request to the agent:
 ```shell
-curl localhost:8080/ResearchReport/generate \
+curl localhost:8080/restate/call/ResearchReport/generate \
 --json '{
     "topic": "Benefits of durable execution in distributed systems"
 }'
@@ -199,7 +199,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ResearchReport/generate \
+curl localhost:8080/restate/call/ResearchReport/generate \
   --json '{"topic": "The impact of renewable energy on global economies"}'
 ```
 </Accordion>
@@ -271,7 +271,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ResearchReport/user123/generate \
+curl localhost:8080/restate/call/ResearchReport/user123/generate \
   --json '{
     "sessionId": "session-123",
     "topic": "The impact of renewable energy on global economies"
@@ -351,7 +351,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ResearchReport/generate \
+curl localhost:8080/restate/call/ResearchReport/generate \
   --json '{"topic": "The impact of renewable energy on global economies"}'
 ```
 </Accordion>
@@ -423,7 +423,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ResearchReport/generate \
+curl localhost:8080/restate/call/ResearchReport/generate \
   --json '{"topic": "The impact of renewable energy on global economies"}'
 ```
 </Accordion>
@@ -508,7 +508,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ResearchReport/generate \
+curl localhost:8080/restate/call/ResearchReport/generate \
   --json '{"topic": "The impact of renewable energy on global economies"}'
 ```
 </Accordion>
@@ -583,7 +583,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ResearchReport/generate \
+curl localhost:8080/restate/call/ResearchReport/generate \
   --json '{"topic": "The impact of renewable energy on global economies"}'
 ```
 </Accordion>

--- a/docs/ai/patterns/workflow-parallel.mdx
+++ b/docs/ai/patterns/workflow-parallel.mdx
@@ -85,7 +85,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents in parallel:
 ```bash
-curl localhost:8080/ParallelAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/ParallelAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -142,7 +142,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents in parallel:
 ```bash
-curl localhost:8080/ParallelAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/ParallelAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -205,7 +205,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents in parallel:
 ```bash
-curl localhost:8080/ParallelAgentClaimApproval/user123/run --json '{
+curl localhost:8080/restate/call/ParallelAgentClaimApproval/user123/run --json '{
     "amount": 3000,
     "category": "orthopedic",
     "date": "2024-10-01",
@@ -260,7 +260,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents in parallel:
 ```bash
-curl localhost:8080/ParallelAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/ParallelAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -322,7 +322,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Start a request for a claim that needs to be analyzed by multiple agents in parallel:
 ```bash
-curl localhost:8080/ParallelAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/ParallelAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -401,7 +401,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ParallelAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/ParallelAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",
@@ -480,7 +480,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ParallelAgentClaimApproval/run --json '{
+curl localhost:8080/restate/call/ParallelAgentClaimApproval/run --json '{
     "date":"2024-10-01",
     "category":"orthopedic",
     "reason":"hospital bill for a broken leg",

--- a/docs/ai/patterns/workflow-sequential.mdx
+++ b/docs/ai/patterns/workflow-sequential.mdx
@@ -108,7 +108,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request to the agent:
 ```shell
-curl localhost:8080/ClaimReimbursement/process --json '{
+curl localhost:8080/restate/call/ClaimReimbursement/process --json '{
     "prompt": "Process my hospital bill of 2024-10-01 for 3000USD for a broken leg at General Hospital."
 }'
 ```
@@ -179,7 +179,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ClaimReimbursement/process --json '{
+curl localhost:8080/restate/call/ClaimReimbursement/process --json '{
     "message": "Process my hospital bill of 2024-10-01 for 3000USD for a broken leg at General Hospital."
 }'
 ```
@@ -266,7 +266,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ClaimReimbursement/user123/process \
+curl localhost:8080/restate/call/ClaimReimbursement/user123/process \
   --json '{
     "sessionId": "session-123",
     "message": "Hospital bill for a broken leg. Amount: 3000 EUR. Date: 2024-10-01. Hospital: General Hospital."
@@ -344,7 +344,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ClaimReimbursement/process --json '{
+curl localhost:8080/restate/call/ClaimReimbursement/process --json '{
     "message": "Process my hospital bill of 2024-10-01 for 3000USD for a broken leg at General Hospital."
 }'
 ```
@@ -419,7 +419,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ClaimReimbursement/process --json '{
+curl localhost:8080/restate/call/ClaimReimbursement/process --json '{
     "message": "Process my hospital bill of 2024-10-01 for 3000USD for a broken leg at General Hospital."
 }'
 ```
@@ -493,7 +493,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ClaimReimbursement/process --json '{
+curl localhost:8080/restate/call/ClaimReimbursement/process --json '{
     "message": "Process my hospital bill of 2024-10-01 for 3000USD for a broken leg at General Hospital."
 }'
 ```
@@ -577,7 +577,7 @@ restate deployments register http://localhost:9080 --force --yes # dev only: ove
 
 Send a request:
 ```bash
-curl localhost:8080/ClaimReimbursement/process --json '{
+curl localhost:8080/restate/call/ClaimReimbursement/process --json '{
     "message": "Process my hospital bill of 2024-10-01 for 3000USD for a broken leg at General Hospital."
 }'
 ```

--- a/docs/cloud/getting-started.mdx
+++ b/docs/cloud/getting-started.mdx
@@ -83,7 +83,7 @@ restate cloud env tunnel --remote-port 8080
 
 Now you can call your service handlers over HTTP on `localhost:8080` (Restate Cloud's ingress port):
 ```bash
-curl localhost:8080/MyService/myHandler
+curl localhost:8080/restate/call/MyService/myHandler
 ```
 
 </Step>
@@ -107,7 +107,7 @@ To create an API key, go to the Developers tab in the Cloud UI.
 Now you can call your service handlers by including the API Key as a Bearer token like this:
 
 ```bash
-curl -H "Authorization: Bearer $RESTATE_AUTH_TOKEN" https://201hy10cd3h6426jy80tb32n6en.env.us.restate.cloud:8080/MyService/MyHandler
+curl -H "Authorization: Bearer $RESTATE_AUTH_TOKEN" https://201hy10cd3h6426jy80tb32n6en.env.us.restate.cloud:8080/restate/call/MyService/MyHandler
 curl -H "Authorization: Bearer $RESTATE_AUTH_TOKEN" https://201hy10cd3h6426jy80tb32n6en.env.us.restate.cloud:9070/deployments
 ```
 

--- a/docs/foundations/invocations.mdx
+++ b/docs/foundations/invocations.mdx
@@ -14,7 +14,7 @@ To call a function over HTTP, send a request to the Restate Server, specifying t
 
 For example, to call the `processPayment` function of the `PaymentService`:
 ```bash
-curl -X POST localhost:8080/PaymentService/processPayment \
+curl -X POST localhost:8080/restate/call/PaymentService/processPayment \
 --json '{"amount": 100, "currency": "USD"}'
 ```
 
@@ -25,7 +25,7 @@ To call Virtual Objects or Workflows, you need to specify the object key or work
 For example, to call `updateBalance` of the `UserAccount` object with key `user123`:
 
 ```bash
-curl -X POST localhost:8080/UserAccount/user123/updateBalance \
+curl -X POST localhost:8080/restate/call/UserAccount/user123/updateBalance \
 --json '{"amount": 50}'
 ```
 
@@ -82,7 +82,7 @@ Consult the [Kafka Quickstart](/guides/kafka-quickstart) to get started.
 Add an idempotency key to your request header to let Restate deduplicate retries:
 
 ```bash
-curl -X POST localhost:8080/PaymentService/processPayment \
+curl -X POST localhost:8080/restate/call/PaymentService/processPayment \
 -H 'idempotency-key: payment-123' \
 --json '{"amount": 100, "currency": "USD"}'
 ```
@@ -141,7 +141,7 @@ response, err := restate.AttachInvocation[string](ctx, invocationId).Response()
 
 Or over HTTP:
 ```bash
-curl localhost:8080/restate/invocation/inv_1234567890abcdef/attach
+curl localhost:8080/restate/attach/inv_1234567890abcdef
 ```
 
 This is useful when another process needs the result of an ongoing operation or wants to check whether it has completed.

--- a/docs/guides/cluster.mdx
+++ b/docs/guides/cluster.mdx
@@ -46,9 +46,9 @@ This guide shows how to deploy a distributed Restate cluster consisting of three
     You can invoke the registered service at any of the started Restate nodes since they all run the ingress.
 
     ```shell
-    curl localhost:8080/Greeter/greet --json '"Sarah"' &&
-    curl localhost:28080/Greeter/greet --json '"Bob"' &&
-    curl localhost:38080/Greeter/greet --json '"Eve"'
+    curl localhost:8080/restate/call/Greeter/greet --json '"Sarah"' &&
+    curl localhost:28080/restate/call/Greeter/greet --json '"Bob"' &&
+    curl localhost:38080/restate/call/Greeter/greet --json '"Eve"'
     ```
 </Step>
 

--- a/docs/guides/cron.mdx
+++ b/docs/guides/cron.mdx
@@ -509,7 +509,7 @@ Usage:
         <CodeGroup>
 
             ```bash TypeScript
-            curl localhost:8080/CronJobInitiator/create --json '{
+            curl localhost:8080/restate/call/CronJobInitiator/create --json '{
               "cronExpression": "* * * * *",
               "service": "TaskService",
               "method": "executeTask",
@@ -518,7 +518,7 @@ Usage:
             ```
 
             ```bash Java
-            curl localhost:8080/CronJobInitiator/create --json '{
+            curl localhost:8080/restate/call/CronJobInitiator/create --json '{
               "cronExpression": "* * * * *",
               "service": "TaskService",
               "method": "executeTask",
@@ -527,7 +527,7 @@ Usage:
             ```
 
             ```bash Go
-            curl localhost:8080/CronJobInitiator/Create --json '{
+            curl localhost:8080/restate/call/CronJobInitiator/Create --json '{
               "cronExpression": "* * * * *",
               "service": "TaskService",
               "method": "ExecuteTask",
@@ -541,7 +541,7 @@ Usage:
         <CodeGroup>
 
             ```bash TypeScript
-            curl localhost:8080/CronJobInitiator/create --json '{
+            curl localhost:8080/restate/call/CronJobInitiator/create --json '{
               "cronExpression": "0 0 * * *",
               "service": "TaskService",
               "method": "executeTask",
@@ -550,7 +550,7 @@ Usage:
             ```
 
             ```bash Java
-            curl localhost:8080/CronJobInitiator/create --json '{
+            curl localhost:8080/restate/call/CronJobInitiator/create --json '{
               "cronExpression": "0 0 * * *",
               "service": "TaskService",
               "method": "executeTask",
@@ -559,7 +559,7 @@ Usage:
             ```
 
             ```bash Go
-            curl localhost:8080/CronJobInitiator/Create --json '{
+            curl localhost:8080/restate/call/CronJobInitiator/Create --json '{
               "cronExpression": "0 0 * * *",
               "service": "TaskService",
               "method": "ExecuteTask",
@@ -577,15 +577,15 @@ Usage:
         <CodeGroup>
 
             ```bash TypeScript
-            curl localhost:8080/CronJob/myJobId/getInfo
+            curl localhost:8080/restate/call/CronJob/myJobId/getInfo
             ```
 
             ```bash Java
-            curl localhost:8080/CronJob/myJobId/getInfo
+            curl localhost:8080/restate/call/CronJob/myJobId/getInfo
             ```
 
             ```bash Go
-            curl localhost:8080/CronJob/myJobId/GetInfo
+            curl localhost:8080/restate/call/CronJob/myJobId/GetInfo
             ```
 
         </CodeGroup>
@@ -594,15 +594,15 @@ Usage:
         <CodeGroup>
 
             ```bash TypeScript
-            curl localhost:8080/CronJob/myJobId/cancel
+            curl localhost:8080/restate/call/CronJob/myJobId/cancel
             ```
 
             ```bash Java
-            curl localhost:8080/CronJob/myJobId/cancel
+            curl localhost:8080/restate/call/CronJob/myJobId/cancel
             ```
 
             ```bash Go
-            curl localhost:8080/CronJob/myJobId/Cancel
+            curl localhost:8080/restate/call/CronJob/myJobId/Cancel
             ```
 
         </CodeGroup>

--- a/docs/guides/encore.mdx
+++ b/docs/guides/encore.mdx
@@ -170,7 +170,7 @@ export const restateEndpoint = api.raw(
     Send a request to Restate Server's ingress (port 8080), which routes it to your Encore-hosted handler:
 
     ```shell
-    curl localhost:8080/OrderProcessor/process \
+    curl localhost:8080/restate/call/OrderProcessor/process \
       --json '{"id": "order-123", "item": "widget"}'
     ```
 

--- a/docs/guides/parallelizing-work.mdx
+++ b/docs/guides/parallelizing-work.mdx
@@ -278,23 +278,23 @@ restate deployments register localhost:9080
 <Step title="Send a request">
     <CodeGroup>
     ```shell TypeScript
-    curl localhost:8080/worker/run \
+    curl localhost:8080/restate/call/worker/run \
         --json '{"description": "get out of bed,shower,make coffee,have breakfast"}'
     ```
     ```shell Java
-    curl localhost:8080/FanOutWorker/run \
+    curl localhost:8080/restate/call/FanOutWorker/run \
         --json '{"description": "get out of bed,shower,make coffee,have breakfast"}'
     ```
     ```shell Kotlin
-    curl localhost:8080/FanOutWorker/run \
+    curl localhost:8080/restate/call/FanOutWorker/run \
         --json '{"description": "get out of bed,shower,make coffee,have breakfast"}'
     ```
     ```shell Python
-    curl localhost:8080/FanOutWorker/run \
+    curl localhost:8080/restate/call/FanOutWorker/run \
         --json '{"description": "get out of bed,shower,make coffee,have breakfast"}'
     ```
     ```shell Go
-    curl localhost:8080/FanOutWorker/Run \
+    curl localhost:8080/restate/call/FanOutWorker/Run \
         --json '{"description": "get out of bed,shower,make coffee,have breakfast"}'
     ```
     </CodeGroup>

--- a/docs/guides/rate-limiting.mdx
+++ b/docs/guides/rate-limiting.mdx
@@ -943,12 +943,12 @@ func main() {
         <CodeGroup>
 
             ```bash TypeScript
-            curl localhost:8080/limiter/myService-expensiveMethod/setRate \
+            curl localhost:8080/restate/call/limiter/myService-expensiveMethod/setRate \
                 --json '{"newLimit": 1, "newBurst": 1}'
             ```
 
             ```bash Go
-            curl localhost:8080/Limiter/LimitedTask-RunTask/SetRate \
+            curl localhost:8080/restate/call/Limiter/LimitedTask-RunTask/SetRate \
                 --json '{"limit": 1, "burst": 1}'
             ```
 
@@ -964,18 +964,18 @@ func main() {
 
         ```bash TypeScript
         # send one request
-        curl localhost:8080/myService/expensiveMethod
+        curl localhost:8080/restate/call/myService/expensiveMethod
 
         # send lots
-        for i in $(seq 1 30); do curl localhost:8080/myService/expensiveMethod && echo "request completed"; done
+        for i in $(seq 1 30); do curl localhost:8080/restate/call/myService/expensiveMethod && echo "request completed"; done
         ```
 
         ```bash Go
         # send one request
-        curl localhost:8080/LimitedTask/RunTask
+        curl localhost:8080/restate/call/LimitedTask/RunTask
 
         # send lots
-        for i in $(seq 1 30); do curl localhost:8080/LimitedTask/RunTask && echo "request completed"; done
+        for i in $(seq 1 30); do curl localhost:8080/restate/call/LimitedTask/RunTask && echo "request completed"; done
         ```
 
         </CodeGroup>

--- a/docs/guides/sagas.mdx
+++ b/docs/guides/sagas.mdx
@@ -341,7 +341,7 @@ Restate automatically retries transient failures (network hiccups, temporary out
     <CodeGroup>
 
     ```bash TypeScript
-    curl localhost:8080/BookingWorkflow/run --json '{
+    curl localhost:8080/restate/call/BookingWorkflow/run --json '{
             "flight": {
                 "flightId": "12345",
                 "passengerName": "John Doe"
@@ -358,7 +358,7 @@ Restate automatically retries transient failures (network hiccups, temporary out
     ```
 
     ```bash Java
-    curl localhost:8080/BookingWorkflow/run --json '{
+    curl localhost:8080/restate/call/BookingWorkflow/run --json '{
             "flight": {
                 "flightId": "12345",
                 "passengerName": "John Doe"
@@ -375,7 +375,7 @@ Restate automatically retries transient failures (network hiccups, temporary out
     ```
 
     ```bash Kotlin
-    curl localhost:8080/BookingWorkflow/run --json '{
+    curl localhost:8080/restate/call/BookingWorkflow/run --json '{
             "flight": {
                 "flightId": "12345",
                 "passengerName": "John Doe"
@@ -392,7 +392,7 @@ Restate automatically retries transient failures (network hiccups, temporary out
     ```
 
     ```bash Python
-    curl localhost:8080/BookingWorkflow/run --json '{
+    curl localhost:8080/restate/call/BookingWorkflow/run --json '{
             "flight": {
                 "flightId": "12345",
                 "passengerName": "John Doe"
@@ -409,7 +409,7 @@ Restate automatically retries transient failures (network hiccups, temporary out
     ```
 
     ```bash Go
-    curl localhost:8080/BookingWorkflow/Run --json '{
+    curl localhost:8080/restate/call/BookingWorkflow/Run --json '{
             "flight": {
                 "flightId": "12345",
                 "passengerName": "John Doe"

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -960,7 +960,7 @@ fun main() {
                 Or invoke via `curl`:
 
                 ```shell
-                curl localhost:8080/Greeter/Greet --json '"Sarah"'
+                curl localhost:8080/restate/call/Greeter/Greet --json '"Sarah"'
                 ```
 
                 Expected output:
@@ -1010,7 +1010,7 @@ func (Greeter) Greet(ctx restate.Context, name string) (string, error) {
 
                 Send a request for `Alice` to see how the service behaves when it occasionally fails to send the reminder and notification:
                 ```shell
-                curl localhost:8080/Greeter/Greet --json '"Alice"'
+                curl localhost:8080/restate/call/Greeter/Greet --json '"Alice"'
                 ```
                 Expected output:
                 ```
@@ -1127,7 +1127,7 @@ async def greet(ctx: restate.Context, req: GreetingRequest) -> Greeting:
 
                         Or invoke via `curl`:
                         ```shell
-                        curl localhost:8080/Greeter/greet --json '"Sarah"'
+                        curl localhost:8080/restate/call/Greeter/greet --json '"Sarah"'
                         ```
 
                         Expected output:
@@ -1179,7 +1179,7 @@ async fn main() {
 <GitHubLink url="https://github.com/restatedev/examples/blob/main/rust/templates/rust/src/main.rs" />
                         Send a request for `Alice` to see how the service behaves when it occasionally fails to send the reminder and notification:
                         ```shell
-                        curl localhost:8080/Greeter/greet --json '"Alice"'
+                        curl localhost:8080/restate/call/Greeter/greet --json '"Alice"'
                         ```
                         Example output:
                         ```shell
@@ -1264,7 +1264,7 @@ async fn main() -> Result<RestateShuttleEndpoint, shuttle_runtime::Error> {
 
                         Send a request for `Alice` to see how the service behaves when it occasionally fails to send the reminder and notification:
                         ```shell
-                        curl localhost:8080/Greeter/greet --json '"Alice"'
+                        curl localhost:8080/restate/call/Greeter/greet --json '"Alice"'
                         ```
                         Example output:
                         ```shell

--- a/docs/services/invocation/http.mdx
+++ b/docs/services/invocation/http.mdx
@@ -83,8 +83,8 @@ Example output:
 {"invocationId":"inv_1aiqX0vFEFNH1Umgre58JiCLgHfTtztYK5","status":"Accepted"}
 ```
 
-The response contains the [Invocation ID](#invocation-identifier).
-You can use this identifier [to cancel](#cancelling-invocations) or [kill the invocation](#killing-invocations).
+The response contains the [Invocation ID](/services/invocation/managing-invocations#invocation-id).
+You can use this identifier [to cancel](/services/invocation/managing-invocations#cancel) or [kill the invocation](/services/invocation/managing-invocations#kill).
 
 ## Delayed messages
 
@@ -190,23 +190,28 @@ curl localhost:8080/restate/output/myInvocationId
 
 ### By target
 
-If you don't have the invocation ID, send a `POST` request to `/restate/attach` or `/restate/output` with a JSON body describing the workflow or idempotency target:
+If you don't have the invocation ID, send a `POST` request to `/restate/attach` or `/restate/output` with a JSON body describing the workflow or idempotency target. You can also address an invocation by its ID through the same body shape, as an alternative to the `GET` form above:
 
 <CodeGroup>
 
     ```shell Workflow
     curl localhost:8080/restate/attach \
-      --json '{"type": "workflow", "name": "MyWorkflow", "key": "myWorkflowId"}'
+      --json '{"target": "workflow", "workflowName": "MyWorkflow", "workflowKey": "myWorkflowId"}'
     ```
 
     ```shell Service
     curl localhost:8080/restate/attach \
-      --json '{"type": "idempotency", "service": "MyService", "handler": "myHandler", "idempotencyKey": "myIdempotencyKey"}'
+      --json '{"target": "idempotentInvocation", "service": "MyService", "handler": "myHandler", "idempotencyKey": "myIdempotencyKey"}'
     ```
 
     ```shell Virtual Object
     curl localhost:8080/restate/attach \
-      --json '{"type": "idempotency", "service": "MyVirtualObject", "serviceKey": "myKey", "handler": "myHandler", "idempotencyKey": "myIdempotencyKey"}'
+      --json '{"target": "idempotentInvocation", "service": "MyVirtualObject", "key": "myKey", "handler": "myHandler", "idempotencyKey": "myIdempotencyKey"}'
+    ```
+
+    ```shell Invocation ID
+    curl localhost:8080/restate/attach \
+      --json '{"target": "invocation", "invocationId": "myInvocationId"}'
     ```
 
 </CodeGroup>
@@ -220,7 +225,7 @@ To resolve a workflow or idempotency target into its invocation ID, send a `POST
 
 ```shell
 curl localhost:8080/restate/lookup \
-  --json '{"type": "workflow", "name": "MyWorkflow", "key": "myWorkflowId"}'
+  --json '{"target": "workflow", "workflowName": "MyWorkflow", "workflowKey": "myWorkflowId"}'
 ```
 
 The response contains the invocation ID, which you can then pass to the `GET` attach and output endpoints:

--- a/docs/services/invocation/http.mdx
+++ b/docs/services/invocation/http.mdx
@@ -16,28 +16,47 @@ Open the UI at port 9070, register your service, click on the service, open the 
     Have a look at [managing invocations](/services/invocation/managing-invocations) to learn how to manage the lifecycle of an invocation.
 </Info>
 
+All ingress endpoints live under the reserved `/restate/` path prefix.
+To invoke a handler, use `/restate/call/...` to wait for the response or `/restate/send/...` to send a message without waiting:
+
+```
+# Request-response
+POST /restate/call/{service}/{handler}
+POST /restate/call/{service}/{key}/{handler}
+
+# Send a message (no response)
+POST /restate/send/{service}/{handler}
+POST /restate/send/{service}/{key}/{handler}
+```
+
+Add the `{key}` segment for Virtual Objects and Workflows; omit it for basic Services.
+
+<Note title="Unversioned paths">
+    The unversioned paths (`/{service}/{handler}`, `/{service}/{key}/{handler}`, and the `/send` suffix) still work for backwards compatibility, but new code should use the `/restate/` paths documented here.
+</Note>
+
 ## Request-response calls
 You can invoke services over HTTP 1.1 or higher.
 Request/response bodies should be encoded as JSON.
 
-Invoking `myHandler` of `myService` as follows:
+Invoke `myHandler` of `MyService` as follows:
 
 ```shell
-curl localhost:8080/MyService/myHandler \
+curl localhost:8080/restate/call/MyService/myHandler \
   --json '{"name": "Mary", "age": 25}'
 ```
 
-Invoke `myHandler` of `myVirtualObject` for `myObjectKey` as follows:
+Invoke `myHandler` of `MyVirtualObject` for `myObjectKey` as follows:
 
 ```shell
-curl localhost:8080/MyVirtualObject/myObjectKey/myHandler \
+curl localhost:8080/restate/call/MyVirtualObject/myObjectKey/myHandler \
   --json '{"name": "Mary", "age": 25}'
 ```
 
 Call the `run` handler of the `MyWorkflow` as follows:
 
 ```shell
-curl localhost:8080/MyWorkflow/myWorkflowId/run \
+curl localhost:8080/restate/call/MyWorkflow/myWorkflowId/run \
   --json '{"name": "Mary", "age": 25}'
 ```
 
@@ -51,10 +70,10 @@ Follow the same pattern for calling the other handlers of the workflow.
 </Note>
 
 ## Sending messages
-If you do not want to wait for the response, you can also send a message by adding `/send` to the URL path:
+If you do not want to wait for the response, you can send a message by using `/restate/send/...` instead of `/restate/call/...`:
 
 ```shell
-curl localhost:8080/MyService/myHandler/send \
+curl localhost:8080/restate/send/MyService/myHandler \
   --json '{"name": "Mary", "age": 25}'
 ```
 
@@ -74,12 +93,12 @@ You can **delay the message** by adding a delay request parameter in ISO8601 not
 <CodeGroup>
 
     ```shell humantime
-    curl "localhost:8080/MyService/myHandler/send?delay=10s" \
+    curl "localhost:8080/restate/send/MyService/myHandler?delay=10s" \
         --json '{"name": "Mary", "age": 25}'
     ```
 
     ```shell ISO8601
-    curl "localhost:8080/MyService/myHandler/send?delay=PT10S" \
+    curl "localhost:8080/restate/send/MyService/myHandler?delay=PT10S" \
         --json '{"name": "Mary", "age": 25}'
     ```
 
@@ -96,7 +115,7 @@ You can **delay the message** by adding a delay request parameter in ISO8601 not
 You can send requests to Restate providing an idempotency key, through the [`Idempotency-Key` header](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/):
 
 ```shell
-curl localhost:8080/MyService/myHandler \
+curl localhost:8080/restate/call/MyService/myHandler \
   -H 'idempotency-key: ad5472esg4dsg525dssdfa5loi' \
   --json '{"name": "Mary", "age": 25}'
 ```
@@ -113,6 +132,29 @@ Check out the [service configuration docs](/services/configuration) to tune the 
 </Tip>
 
 
+## Scopes
+
+<Note title="Experimental">
+    Scopes are part of the flow control feature.
+    Scoped invocations are rejected unless the server is started with the experimental `vqueues` feature enabled (`experimental-enable-vqueues = true`).
+</Note>
+
+A scope is an opaque key that assigns an invocation to scope, which Restate uses to apply flow control across invocations that share the same scope.
+Add a `scope/{scopeKey}` segment in front of the `call` or `send` verb:
+
+```
+POST /restate/scope/{scopeKey}/call/{service}/{handler}
+POST /restate/scope/{scopeKey}/call/{service}/{key}/{handler}
+POST /restate/scope/{scopeKey}/send/{service}/{handler}
+POST /restate/scope/{scopeKey}/send/{service}/{key}/{handler}
+```
+
+For example, to call `MyService/myHandler` within the scope `tenant-a`:
+
+```shell
+curl localhost:8080/restate/scope/tenant-a/call/MyService/myHandler \
+  --json '{"name": "Mary", "age": 25}'
+```
 
 ## Cancel
 
@@ -129,32 +171,62 @@ curl -X PATCH http://localhost:9070/invocations/inv_1gdJBtdVEcM942bjcDmb1c1khoaJ
 
 ## Attach to an invocation
 
-Restate allows you to retrieve the result of workflows and invocations with an idempotency key.
+Restate allows you to retrieve the result of workflows and invocations that used an idempotency key.
 There are two options:
-- To **attach** to an invocation or workflow and wait for it to finish, use `/attach`.
-- To **peek at the output** of an invocation or workflow, use `/output`. This will return:
-    - `{"message":"not ready"}` for ongoing workflows
-    - The result for finished workflows
-    - `{"message":"not found"}` for non-existing workflows
+- To **attach** to an invocation or workflow and wait for it to finish, use `attach`.
+- To **peek at the output** of an invocation or workflow, use `output`. This will return:
+    - `{"message":"not ready"}` for ongoing invocations
+    - The result for finished invocations
+    - `{"message":"not found"}` for non-existing invocations
 
-You can attach to a service/object invocation only if the invocation used an idempotency key:
+### By invocation ID
+
+If you already have the invocation ID, attach to it or read its output with a `GET` request:
 
 ```shell
-# Via invocation ID
-curl localhost:8080/restate/invocation/myInvocationId/attach
-curl localhost:8080/restate/invocation/myInvocationId/output
+curl localhost:8080/restate/attach/myInvocationId
+curl localhost:8080/restate/output/myInvocationId
+```
 
-# For Services, via idempotency key
-curl localhost:8080/restate/invocation/MyService/myHandler/myIdempotencyKey/attach
-curl localhost:8080/restate/invocation/MyService/myHandler/myIdempotencyKey/output
+### By target
 
-# For Virtual Objects, via idempotency key
-curl localhost:8080/restate/invocation/myObject/myKey/myHandler/myIdempotencyKey/attach
-curl localhost:8080/restate/invocation/myObject/myKey/myHandler/myIdempotencyKey/output
+If you don't have the invocation ID, send a `POST` request to `/restate/attach` or `/restate/output` with a JSON body describing the workflow or idempotency target:
 
-# For Workflows, with the Workflow ID
-curl localhost:8080/restate/workflow/MyWorkflow/myWorkflowId/attach
-curl localhost:8080/restate/workflow/MyWorkflow/myWorkflowId/output
+<CodeGroup>
+
+    ```shell Workflow
+    curl localhost:8080/restate/attach \
+      --json '{"type": "workflow", "name": "MyWorkflow", "key": "myWorkflowId"}'
+    ```
+
+    ```shell Service
+    curl localhost:8080/restate/attach \
+      --json '{"type": "idempotency", "service": "MyService", "handler": "myHandler", "idempotencyKey": "myIdempotencyKey"}'
+    ```
+
+    ```shell Virtual Object
+    curl localhost:8080/restate/attach \
+      --json '{"type": "idempotency", "service": "MyVirtualObject", "serviceKey": "myKey", "handler": "myHandler", "idempotencyKey": "myIdempotencyKey"}'
+    ```
+
+</CodeGroup>
+
+Use the same body shape against `/restate/output` to peek at the result.
+If the target was invoked within a [scope](#scopes), add the optional `"scope"` field to the body.
+
+### Looking up the invocation ID
+
+To resolve a workflow or idempotency target into its invocation ID, send a `POST` request to `/restate/lookup` with the same body shape as above:
+
+```shell
+curl localhost:8080/restate/lookup \
+  --json '{"type": "workflow", "name": "MyWorkflow", "key": "myWorkflowId"}'
+```
+
+The response contains the invocation ID, which you can then pass to the `GET` attach and output endpoints:
+
+```json
+{"invocationId": "inv_1aiqX0vFEFNH1Umgre58JiCLgHfTtztYK5"}
 ```
 
 ## OpenAPI support

--- a/docs/snippets/quickstart/durable-execution-explanation-request.mdx
+++ b/docs/snippets/quickstart/durable-execution-explanation-request.mdx
@@ -1,7 +1,7 @@
 
 Send a request for `Alice` to see how the service behaves when it occasionally fails to send the reminder and notification:
 ```shell
-curl localhost:8080/Greeter/greet --json '{"name": "Alice"}'
+curl localhost:8080/restate/call/Greeter/greet --json '{"name": "Alice"}'
 ```
 Expected output:
 ```shell

--- a/docs/snippets/quickstart/send-request.mdx
+++ b/docs/snippets/quickstart/send-request.mdx
@@ -4,7 +4,7 @@ Invoke the service via the Restate UI playground: go to `http://localhost:9070`,
 
 Or invoke via `curl`:
 ```shell
-curl localhost:8080/Greeter/greet --json '{"name": "Sarah"}'
+curl localhost:8080/restate/call/Greeter/greet --json '{"name": "Sarah"}'
 ```
 
 Expected output: `You said hi to Sarah!`

--- a/docs/tour/microservice-orchestration.mdx
+++ b/docs/tour/microservice-orchestration.mdx
@@ -189,7 +189,7 @@ This registers a set of services that we will be covering in this tutorial.
 
 To invoke a handler, send a request to `restate-ingress/MyServiceName/handlerName`:
 ```bash
-curl localhost:8080/SubscriptionService/add \
+curl localhost:8080/restate/call/SubscriptionService/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime"]}'
 ```
 
@@ -214,7 +214,7 @@ This registers a set of services that we will be covering in this tutorial.
 
 To invoke a handler, send a request to `restate-ingress/MyServiceName/handlerName`:
 ```bash
-curl localhost:8080/SubscriptionService/add \
+curl localhost:8080/restate/call/SubscriptionService/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime"]}'
 ```
 </GlobalTab>
@@ -238,7 +238,7 @@ This registers a set of services that we will be covering in this tutorial.
 
 To invoke a handler, send a request to `restate-ingress/MyServiceName/handlerName`:
 ```bash
-curl localhost:8080/SubscriptionService/Add \
+curl localhost:8080/restate/call/SubscriptionService/Add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime"]}'
 ```
 </GlobalTab>
@@ -262,7 +262,7 @@ This registers a set of services that we will be covering in this tutorial.
 
 To invoke a handler, send a request to `restate-ingress/MyServiceName/handlerName`:
 ```bash
-curl localhost:8080/SubscriptionService/add \
+curl localhost:8080/restate/call/SubscriptionService/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime"]}'
 ```
 
@@ -297,7 +297,7 @@ This process continues until the handler runs till completion.
 <GlobalTab title="TypeScript">
 Try to add a subscription for Netflix:
 ```bash
-curl localhost:8080/SubscriptionService/add \
+curl localhost:8080/restate/call/SubscriptionService/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "Netflix"]}'
 ```
 
@@ -326,7 +326,7 @@ export function createSubscription(
 <GlobalTab title="Java">
 Try to add a subscription for Netflix:
 ```bash
-curl localhost:8080/SubscriptionService/add \
+curl localhost:8080/restate/call/SubscriptionService/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "Netflix"]}'
 ```
 
@@ -352,7 +352,7 @@ public static String createSubscription(String userId, String subscription, Stri
 <GlobalTab title="Go">
 Try to add a subscription for Netflix:
 ```bash
-curl localhost:8080/SubscriptionService/Add \
+curl localhost:8080/restate/call/SubscriptionService/Add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "Netflix"]}'
 ```
 
@@ -380,7 +380,7 @@ func CreateSubscription(userId, subscription, paymentRef string) (string, error)
 <GlobalTab title="Python">
 Try to add a subscription for Netflix:
 ```bash
-curl localhost:8080/SubscriptionService/add \
+curl localhost:8080/restate/call/SubscriptionService/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "Netflix"]}'
 ```
 
@@ -747,25 +747,25 @@ Add a subscription for Disney:
 <GlobalTabs className={"hidden-tabs"}>
 <GlobalTab title="TypeScript">
 ```bash
-curl localhost:8080/SubscriptionSaga/add \
+curl localhost:8080/restate/call/SubscriptionSaga/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "Disney"]}'
 ```
 </GlobalTab>
 <GlobalTab title="Java">
 ```bash
-curl localhost:8080/SubscriptionSaga/add \
+curl localhost:8080/restate/call/SubscriptionSaga/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "Disney"]}'
 ```
 </GlobalTab>
 <GlobalTab title="Go">
 ```bash
-curl localhost:8080/SubscriptionSaga/Add \
+curl localhost:8080/restate/call/SubscriptionSaga/Add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "Disney"]}'
 ```
 </GlobalTab>
 <GlobalTab title="Python">
 ```bash
-curl localhost:8080/SubscriptionSaga/add \
+curl localhost:8080/restate/call/SubscriptionSaga/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "Disney"]}'
 ```
 </GlobalTab>
@@ -977,54 +977,54 @@ To call a Virtual Object, you specify the object key in the URL (here `user-123`
 <GlobalTabs className={"hidden-tabs"}>
 <GlobalTab title="TypeScript">
 ```bash
-curl localhost:8080/UserSubscriptions/user-123/add --json '"Hulu"'
-curl localhost:8080/UserSubscriptions/user-123/add --json '"Prime"'
-curl localhost:8080/UserSubscriptions/user-123/add --json '"Disney"'
-curl localhost:8080/UserSubscriptions/user-456/add --json '"Netflix"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/add --json '"Hulu"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/add --json '"Prime"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/add --json '"Disney"'
+curl localhost:8080/restate/call/UserSubscriptions/user-456/add --json '"Netflix"'
 ```
 
 Get the subscriptions for `user-123`:
 ```bash
-curl localhost:8080/UserSubscriptions/user-123/getSubscriptions
+curl localhost:8080/restate/call/UserSubscriptions/user-123/getSubscriptions
 ```
 </GlobalTab>
 <GlobalTab title="Java">
 ```bash
-curl localhost:8080/UserSubscriptions/user-123/add --json '"Hulu"'
-curl localhost:8080/UserSubscriptions/user-123/add --json '"Prime"'
-curl localhost:8080/UserSubscriptions/user-123/add --json '"Disney"'
-curl localhost:8080/UserSubscriptions/user-456/add --json '"Netflix"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/add --json '"Hulu"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/add --json '"Prime"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/add --json '"Disney"'
+curl localhost:8080/restate/call/UserSubscriptions/user-456/add --json '"Netflix"'
 ```
 
 Get the subscriptions for `user-123`:
 ```bash
-curl localhost:8080/UserSubscriptions/user-123/getSubscriptions
+curl localhost:8080/restate/call/UserSubscriptions/user-123/getSubscriptions
 ```
 </GlobalTab>
 <GlobalTab title="Go">
 ```bash
-curl localhost:8080/UserSubscriptions/user-123/Add --json '"Hulu"'
-curl localhost:8080/UserSubscriptions/user-123/Add --json '"Prime"'
-curl localhost:8080/UserSubscriptions/user-123/Add --json '"Disney"'
-curl localhost:8080/UserSubscriptions/user-456/Add --json '"Netflix"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/Add --json '"Hulu"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/Add --json '"Prime"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/Add --json '"Disney"'
+curl localhost:8080/restate/call/UserSubscriptions/user-456/Add --json '"Netflix"'
 ```
 
 Get the subscriptions for `user-123`:
 ```bash
-curl localhost:8080/UserSubscriptions/user-123/GetSubscriptions
+curl localhost:8080/restate/call/UserSubscriptions/user-123/GetSubscriptions
 ```
 </GlobalTab>
 <GlobalTab title="Python">
 ```bash
-curl localhost:8080/UserSubscriptions/user-123/add --json '"Hulu"'
-curl localhost:8080/UserSubscriptions/user-123/add --json '"Prime"'
-curl localhost:8080/UserSubscriptions/user-123/add --json '"Disney"'
-curl localhost:8080/UserSubscriptions/user-456/add --json '"Netflix"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/add --json '"Hulu"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/add --json '"Prime"'
+curl localhost:8080/restate/call/UserSubscriptions/user-123/add --json '"Disney"'
+curl localhost:8080/restate/call/UserSubscriptions/user-456/add --json '"Netflix"'
 ```
 
 Get the subscriptions for `user-123`:
 ```bash
-curl localhost:8080/UserSubscriptions/user-123/getSubscriptions
+curl localhost:8080/restate/call/UserSubscriptions/user-123/getSubscriptions
 ```
 </GlobalTab>
 </GlobalTabs>
@@ -1152,7 +1152,7 @@ Buy a concert ticket:
 <GlobalTabs className={"hidden-tabs"}>
 <GlobalTab title="TypeScript">
 ```bash
-curl localhost:8080/ConcertTicketingService/buy --json '{
+curl localhost:8080/restate/call/ConcertTicketingService/buy --json '{
 "ticketId": "ticket-789",
 "price": 100,
 "customerEmail": "me@mail.com",
@@ -1162,7 +1162,7 @@ curl localhost:8080/ConcertTicketingService/buy --json '{
 </GlobalTab>
 <GlobalTab title="Java">
 ```bash
-curl localhost:8080/ConcertTicketingService/buy --json '{
+curl localhost:8080/restate/call/ConcertTicketingService/buy --json '{
 "ticketId": "ticket-789",
 "price": 100,
 "customerEmail": "me@mail.com",
@@ -1172,7 +1172,7 @@ curl localhost:8080/ConcertTicketingService/buy --json '{
 </GlobalTab>
 <GlobalTab title="Go">
 ```bash
-curl localhost:8080/ConcertTicketingService/Buy --json '{
+curl localhost:8080/restate/call/ConcertTicketingService/Buy --json '{
 "ticketId": "ticket-789",
 "price": 100,
 "customerEmail": "me@mail.com",
@@ -1182,7 +1182,7 @@ curl localhost:8080/ConcertTicketingService/Buy --json '{
 </GlobalTab>
 <GlobalTab title="Python">
 ```bash
-curl localhost:8080/ConcertTicketingService/buy --json '{
+curl localhost:8080/restate/call/ConcertTicketingService/buy --json '{
 "ticketId": "ticket-789",
 "price": 100,
 "customerEmail": "me@mail.com",
@@ -1211,7 +1211,7 @@ Add an idempotency header to your request:
 <GlobalTab title="TypeScript">
 
 ```shell
-curl -X POST localhost:8080/ConcertTicketingService/buy \
+curl -X POST localhost:8080/restate/call/ConcertTicketingService/buy \
 -H 'Idempotency-Key: unique-key-123' \
 --json '{"ticketId": "ticket-789", "price": 100, "customerEmail": "me@mail.com", "concertDate": "2023-10-01T20:00:00Z"}'
 ```
@@ -1219,7 +1219,7 @@ curl -X POST localhost:8080/ConcertTicketingService/buy \
 <GlobalTab title="Java">
 
 ```shell
-curl -X POST localhost:8080/ConcertTicketingService/buy \
+curl -X POST localhost:8080/restate/call/ConcertTicketingService/buy \
 -H 'Idempotency-Key: unique-key-123' \
 --json '{"ticketId": "ticket-789", "price": 100, "customerEmail": "me@mail.com", "concertDate": "2023-10-01T20:00:00Z"}'
 ```
@@ -1227,7 +1227,7 @@ curl -X POST localhost:8080/ConcertTicketingService/buy \
 <GlobalTab title="Go">
 
 ```shell
-curl -X POST localhost:8080/ConcertTicketingService/Buy \
+curl -X POST localhost:8080/restate/call/ConcertTicketingService/Buy \
 -H 'Idempotency-Key: unique-key-123' \
 --json '{"ticketId": "ticket-789", "price": 100, "customerEmail": "me@mail.com", "concertDate": "2023-10-01T20:00:00Z"}'
 ```
@@ -1235,7 +1235,7 @@ curl -X POST localhost:8080/ConcertTicketingService/Buy \
 <GlobalTab title="Python">
 
 ```shell
-curl -X POST localhost:8080/ConcertTicketingService/buy \
+curl -X POST localhost:8080/restate/call/ConcertTicketingService/buy \
 -H 'Idempotency-Key: unique-key-123' \
 --json '{"ticketId": "ticket-789", "price": 100, "customerEmail": "me@mail.com", "concertDate": "2023-10-01T20:00:00Z"}'
 ```
@@ -1391,29 +1391,29 @@ You can also use awakeables to implement human-in-the-loop interactions, such as
 
 <Accordion title="Try out external events" icon={"laptop"}>
 
-Initiate a payment by calling the `process` handler. Add `/send` to call the handler without waiting for the response:
+Initiate a payment by calling the `process` handler. Use the `send` verb to call the handler without waiting for the response:
 <GlobalTabs className={"hidden-tabs"}>
 <GlobalTab title="TypeScript">
 ```bash
-curl localhost:8080/Payments/process/send \
+curl localhost:8080/restate/send/Payments/process \
 --json '{"amount": 100, "currency": "USD", "customerId": "cust-123", "orderId": "order-456"}'
 ```
 </GlobalTab>
 <GlobalTab title="Java">
 ```bash
-curl localhost:8080/Payments/process/send \
+curl localhost:8080/restate/send/Payments/process \
 --json '{"amount": 100, "currency": "USD", "customerId": "cust-123", "orderId": "order-456"}'
 ```
 </GlobalTab>
 <GlobalTab title="Go">
 ```bash
-curl localhost:8080/Payments/Process/send \
+curl localhost:8080/restate/send/Payments/Process \
 --json '{"amount": 100, "currency": "USD", "customerId": "cust-123", "orderId": "order-456"}'
 ```
 </GlobalTab>
 <GlobalTab title="Python">
 ```bash
-curl localhost:8080/Payments/process/send \
+curl localhost:8080/restate/send/Payments/process \
 --json '{"amount": 100, "currency": "USD", "customerId": "cust-123", "orderId": "order-456"}'
 ```
 </GlobalTab>
@@ -1427,25 +1427,25 @@ Simulate approving the payment by executing the **curl request that was printed 
 <GlobalTabs className={"hidden-tabs"}>
 <GlobalTab title="TypeScript">
 ```bash
-curl localhost:8080/Payments/confirm \
+curl localhost:8080/restate/call/Payments/confirm \
 --json '{"id": "sign_1PrDkbECjgdsBmMfEUQyCnioCP-csLbd2AAAAEQ", "result": {"success": true, "transactionId": "txn-123"}}'
 ```
 </GlobalTab>
 <GlobalTab title="Java">
 ```bash
-curl localhost:8080/Payments/confirm \
+curl localhost:8080/restate/call/Payments/confirm \
 --json '{"id": "sign_1PrDkbECjgdsBmMfEUQyCnioCP-csLbd2AAAAEQ", "result": {"success": true, "transactionId": "txn-123"}}'
 ```
 </GlobalTab>
 <GlobalTab title="Go">
 ```bash
-curl localhost:8080/Payments/Confirm \
+curl localhost:8080/restate/call/Payments/Confirm \
 --json '{"id": "sign_1PrDkbECjgdsBmMfEUQyCnioCP-csLbd2AAAAEQ", "result": {"success": true, "transactionId": "txn-123"}}'
 ```
 </GlobalTab>
 <GlobalTab title="Python">
 ```bash
-curl localhost:8080/Payments/confirm \
+curl localhost:8080/restate/call/Payments/confirm \
 --json '{"id": "sign_1PrDkbECjgdsBmMfEUQyCnioCP-csLbd2AAAAEQ", "result": {"success": true, "transactionId": "txn-123"}}'
 ```
 </GlobalTab>
@@ -1636,29 +1636,29 @@ You can also set timeouts for RPC calls or other asynchronous operations with th
 
 <Accordion title="Try out durable timers" icon={"laptop"}>
 
-Initiate a payment by calling the `process` handler. Add `/send` to call the handler without waiting for the response:
+Initiate a payment by calling the `process` handler. Use the `send` verb to call the handler without waiting for the response:
 <GlobalTabs className={"hidden-tabs"}>
 <GlobalTab title="TypeScript">
 ```bash
-curl localhost:8080/PaymentsWithTimeout/process/send \
+curl localhost:8080/restate/send/PaymentsWithTimeout/process \
 --json '{"amount": 100, "currency": "USD", "customerId": "cust-123", "orderId": "order-456"}'
 ```
 </GlobalTab>
 <GlobalTab title="Java">
 ```bash
-curl localhost:8080/PaymentsWithTimeout/process/send \
+curl localhost:8080/restate/send/PaymentsWithTimeout/process \
 --json '{"amount": 100, "currency": "USD", "customerId": "cust-123", "orderId": "order-456"}'
 ```
 </GlobalTab>
 <GlobalTab title="Go">
 ```bash
-curl localhost:8080/PaymentsWithTimeout/Process/send \
+curl localhost:8080/restate/send/PaymentsWithTimeout/Process \
 --json '{"amount": 100, "currency": "USD", "customerId": "cust-123", "orderId": "order-456"}'
 ```
 </GlobalTab>
 <GlobalTab title="Python">
 ```bash
-curl localhost:8080/PaymentsWithTimeout/process/send \
+curl localhost:8080/restate/send/PaymentsWithTimeout/process \
 --json '{"amount": 100, "currency": "USD", "customerId": "cust-123", "orderId": "order-456"}'
 ```
 </GlobalTab>
@@ -1833,25 +1833,25 @@ Add a few subscriptions for some users.
 <GlobalTabs className={"hidden-tabs"}>
 <GlobalTab title="TypeScript">
 ```bash
-curl localhost:8080/ParallelSubscriptionService/add \
+curl localhost:8080/restate/call/ParallelSubscriptionService/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "YouTube"]}'
 ```
 </GlobalTab>
 <GlobalTab title="Java">
 ```bash
-curl localhost:8080/ParallelSubscriptionService/add \
+curl localhost:8080/restate/call/ParallelSubscriptionService/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "YouTube"]}'
 ```
 </GlobalTab>
 <GlobalTab title="Go">
 ```bash
-curl localhost:8080/ParallelSubscriptionService/Add \
+curl localhost:8080/restate/call/ParallelSubscriptionService/Add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "YouTube"]}'
 ```
 </GlobalTab>
 <GlobalTab title="Python">
 ```bash
-curl localhost:8080/ParallelSubscriptionService/add \
+curl localhost:8080/restate/call/ParallelSubscriptionService/add \
 --json '{"userId": "user-123", "creditCard": "4111111111111111", "subscriptions": ["Hulu", "Prime", "YouTube"]}'
 ```
 </GlobalTab>

--- a/docs/tour/workflows.mdx
+++ b/docs/tour/workflows.mdx
@@ -261,25 +261,25 @@ To submit the workflow via HTTP send the request to `restate-ingress/workflow-na
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWorkflow/johndoe/run \
+        curl localhost:8080/restate/call/SignupWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWorkflow/johndoe/run \
+        curl localhost:8080/restate/call/SignupWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWorkflow/johndoe/Run \
+        curl localhost:8080/restate/call/SignupWorkflow/johndoe/Run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWorkflow/johndoe/run \
+        curl localhost:8080/restate/call/SignupWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
@@ -377,25 +377,25 @@ You can schedule a workflow to run at a later time by specifying a delay:
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl "localhost:8080/SignupWorkflow/petewhite/run/send?delay=5m" \
+        curl "localhost:8080/restate/send/SignupWorkflow/petewhite/run?delay=5m" \
         --json '{"name": "Pete White", "email": "pete@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl "localhost:8080/SignupWorkflow/petewhite/run/send?delay=5m" \
+        curl "localhost:8080/restate/send/SignupWorkflow/petewhite/run?delay=5m" \
         --json '{"name": "Pete White", "email": "pete@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl "localhost:8080/SignupWorkflow/petewhite/Run/send?delay=5m" \
+        curl "localhost:8080/restate/send/SignupWorkflow/petewhite/Run?delay=5m" \
         --json '{"name": "Pete White", "email": "pete@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl "localhost:8080/SignupWorkflow/petewhite/run/send?delay=5m" \
+        curl "localhost:8080/restate/send/SignupWorkflow/petewhite/run?delay=5m" \
         --json '{"name": "Pete White", "email": "pete@mail.com"}'
         ```
     </GlobalTab>
@@ -408,7 +408,8 @@ Have a look at the SDK docs to learn how to schedule workflows programmatically 
 <Accordion title="Attach to ongoing workflow">
 If a workflow is already ongoing, you can also attach to it to get the result once it finishes:
 ```bash
-curl localhost:8080/restate/workflow/SignupWorkflow/johndoe/attach
+curl localhost:8080/restate/attach \
+  --json '{"type": "workflow", "name": "SignupWorkflow", "key": "johndoe"}'
 ```
 Have a look at the SDK docs to learn how to attach to workflows programmatically ([TS](/services/invocation/clients/typescript-sdk) / [Java](/services/invocation/clients/java-sdk) / [Go](/services/invocation/clients/go-sdk)).
 </Accordion>
@@ -434,25 +435,25 @@ Send a request for Alice:
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWorkflow/alicedoe/run \
+        curl localhost:8080/restate/call/SignupWorkflow/alicedoe/run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWorkflow/alicedoe/run \
+        curl localhost:8080/restate/call/SignupWorkflow/alicedoe/run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWorkflow/alicedoe/Run \
+        curl localhost:8080/restate/call/SignupWorkflow/alicedoe/Run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWorkflow/alicedoe/run \
+        curl localhost:8080/restate/call/SignupWorkflow/alicedoe/run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
@@ -632,25 +633,25 @@ Submit the workflow:
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWithActivitiesWorkflow/carl/run \
+        curl localhost:8080/restate/call/SignupWithActivitiesWorkflow/carl/run \
         --json '{"name": "Carl", "email": "carl@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWithActivitiesWorkflow/carl/run \
+        curl localhost:8080/restate/call/SignupWithActivitiesWorkflow/carl/run \
         --json '{"name": "Carl", "email": "carl@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWithActivitiesWorkflow/carl/Run \
+        curl localhost:8080/restate/call/SignupWithActivitiesWorkflow/carl/Run \
         --json '{"name": "Carl", "email": "carl@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWithActivitiesWorkflow/carl/run \
+        curl localhost:8080/restate/call/SignupWithActivitiesWorkflow/carl/run \
         --json '{"name": "Carl", "email": "carl@mail.com"}'
         ```
     </GlobalTab>
@@ -843,25 +844,25 @@ Submit the workflow:
 <GlobalTabs  className={"hidden-tabs"}>
 <GlobalTab title="TypeScript">
     ```bash
-    curl localhost:8080/SignupWithQueriesWorkflow/janedoe/run \
+    curl localhost:8080/restate/call/SignupWithQueriesWorkflow/janedoe/run \
     --json '{"name": "Jane Doe", "email": "jane@mail.com"}'
     ```
 </GlobalTab>
 <GlobalTab title="Java">
     ```bash
-    curl localhost:8080/SignupWithQueriesWorkflow/janedoe/run \
+    curl localhost:8080/restate/call/SignupWithQueriesWorkflow/janedoe/run \
     --json '{"name": "Jane Doe", "email": "jane@mail.com"}'
     ```
 </GlobalTab>
 <GlobalTab title="Go">
     ```bash
-    curl localhost:8080/SignupWithQueriesWorkflow/janedoe/Run \
+    curl localhost:8080/restate/call/SignupWithQueriesWorkflow/janedoe/Run \
     --json '{"name": "Jane Doe", "email": "jane@mail.com"}'
     ```
 </GlobalTab>
 <GlobalTab title="Python">
     ```bash
-    curl localhost:8080/SignupWithQueriesWorkflow/janedoe/run \
+    curl localhost:8080/restate/call/SignupWithQueriesWorkflow/janedoe/run \
     --json '{"name": "Jane Doe", "email": "jane@mail.com"}'
     ```
 </GlobalTab>
@@ -1019,29 +1020,29 @@ You can use Restate's Durable Promises to handle asynchronous events without com
 Promises can be resolved before the workflow waits for them, avoiding complex synchronization issues.
 
 <Accordion title="Try out signaling" icon={"laptop"}>
-Submit the workflow asynchronously with `/send`:
+Submit the workflow asynchronously with the `send` verb:
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/johndoe/run/send \
+        curl localhost:8080/restate/send/SignupWithSignalsWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/johndoe/run/send \
+        curl localhost:8080/restate/send/SignupWithSignalsWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/johndoe/Run/send \
+        curl localhost:8080/restate/send/SignupWithSignalsWorkflow/johndoe/Run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/johndoe/run/send \
+        curl localhost:8080/restate/send/SignupWithSignalsWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
@@ -1058,25 +1059,25 @@ To resolve the promise, **copy over the curl request from the service logs**, wh
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/johndoe/verifyEmail \
+        curl localhost:8080/restate/call/SignupWithSignalsWorkflow/johndoe/verifyEmail \
         --json '{"secret": "the-secret-from-email"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/johndoe/verifyEmail \
+        curl localhost:8080/restate/call/SignupWithSignalsWorkflow/johndoe/verifyEmail \
         --json '{"secret": "the-secret-from-email"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/johndoe/VerifyEmail \
+        curl localhost:8080/restate/call/SignupWithSignalsWorkflow/johndoe/VerifyEmail \
         --json '{"secret": "the-secret-from-email"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/johndoe/verifyEmail \
+        curl localhost:8080/restate/call/SignupWithSignalsWorkflow/johndoe/verifyEmail \
         --json '{"secret": "the-secret-from-email"}'
         ```
     </GlobalTab>
@@ -1242,50 +1243,50 @@ Here, external clients can wait for the user to be created in the database.
 These handlers can be called up to the workflow's retention period ([default one day](/services/configuration#workflow-retention).
 
 <Accordion title="Try out workflow events" icon={"laptop"}>
-Submit the workflow asynchronously with `/send`:
+Submit the workflow asynchronously with the `send` verb:
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWithEventsWorkflow/johndoe/run/send \
+        curl localhost:8080/restate/send/SignupWithEventsWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
 
         Then wait for the user creation event:
         ```bash
-        curl localhost:8080/SignupWithEventsWorkflow/johndoe/waitForUserCreation
+        curl localhost:8080/restate/call/SignupWithEventsWorkflow/johndoe/waitForUserCreation
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWithEventsWorkflow/johndoe/run/send \
+        curl localhost:8080/restate/send/SignupWithEventsWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
 
         Then wait for the user creation event:
         ```bash
-        curl localhost:8080/SignupWithEventsWorkflow/johndoe/waitForUserCreation
+        curl localhost:8080/restate/call/SignupWithEventsWorkflow/johndoe/waitForUserCreation
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWithEventsWorkflow/johndoe/Run/send \
+        curl localhost:8080/restate/send/SignupWithEventsWorkflow/johndoe/Run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
 
         Then wait for the user creation event:
         ```bash
-        curl localhost:8080/SignupWithEventsWorkflow/johndoe/WaitForUserCreation
+        curl localhost:8080/restate/call/SignupWithEventsWorkflow/johndoe/WaitForUserCreation
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWithEventsWorkflow/johndoe/run/send \
+        curl localhost:8080/restate/send/SignupWithEventsWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
 
         Then wait for the user creation event:
         ```bash
-        curl localhost:8080/SignupWithEventsWorkflow/johndoe/waitForUserCreation
+        curl localhost:8080/restate/call/SignupWithEventsWorkflow/johndoe/waitForUserCreation
         ```
     </GlobalTab>
 </GlobalTabs>
@@ -1528,29 +1529,29 @@ Because Restate lets you write workflows as regular functions, you can use your 
 This makes it easy to implement complex logic with timers, loops, and conditional execution.
 
 <Accordion title="Try out timers" icon={"laptop"}>
-Submit the workflow asynchronously with `/send`:
+Submit the workflow asynchronously with the `send` verb:
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWithTimersWorkflow/johndoe/run/send \
+        curl localhost:8080/restate/send/SignupWithTimersWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWithTimersWorkflow/johndoe/run/send \
+        curl localhost:8080/restate/send/SignupWithTimersWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWithTimersWorkflow/johndoe/Run/send \
+        curl localhost:8080/restate/send/SignupWithTimersWorkflow/johndoe/Run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWithTimersWorkflow/johndoe/run/send \
+        curl localhost:8080/restate/send/SignupWithTimersWorkflow/johndoe/run \
         --json '{"name": "John Doe", "email": "john@mail.com"}'
         ```
     </GlobalTab>
@@ -1568,25 +1569,25 @@ To resolve the promise, **copy over the curl request from the service logs**, wh
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWithTimersWorkflow/johndoe/verifyEmail \
+        curl localhost:8080/restate/call/SignupWithTimersWorkflow/johndoe/verifyEmail \
         --json '{"secret": "the-secret-from-email"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWithTimersWorkflow/johndoe/verifyEmail \
+        curl localhost:8080/restate/call/SignupWithTimersWorkflow/johndoe/verifyEmail \
         --json '{"secret": "the-secret-from-email"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWithTimersWorkflow/johndoe/verifyEmail \
+        curl localhost:8080/restate/call/SignupWithTimersWorkflow/johndoe/verifyEmail \
         --json '{"secret": "the-secret-from-email"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWithTimersWorkflow/johndoe/verifyEmail \
+        curl localhost:8080/restate/call/SignupWithTimersWorkflow/johndoe/verifyEmail \
         --json '{"secret": "the-secret-from-email"}'
         ```
     </GlobalTab>
@@ -1765,25 +1766,25 @@ Submit the workflow for Alice:
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWithRetriesWorkflow/alice/run \
+        curl localhost:8080/restate/call/SignupWithRetriesWorkflow/alice/run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWithRetriesWorkflow/alice/run \
+        curl localhost:8080/restate/call/SignupWithRetriesWorkflow/alice/run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWithRetriesWorkflow/alice/Run \
+        curl localhost:8080/restate/call/SignupWithRetriesWorkflow/alice/Run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWithRetriesWorkflow/alice/run \
+        curl localhost:8080/restate/call/SignupWithRetriesWorkflow/alice/run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
@@ -2016,25 +2017,25 @@ Submit the workflow for Alice:
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWithSagasWorkflow/alice/run \
+        curl localhost:8080/restate/call/SignupWithSagasWorkflow/alice/run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWithSagasWorkflow/alice/run \
+        curl localhost:8080/restate/call/SignupWithSagasWorkflow/alice/run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWithSagasWorkflow/alice/Run \
+        curl localhost:8080/restate/call/SignupWithSagasWorkflow/alice/Run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWithSagasWorkflow/alice/run \
+        curl localhost:8080/restate/call/SignupWithSagasWorkflow/alice/run \
         --json '{"name": "Alice", "email": "alice@mail.com"}'
         ```
     </GlobalTab>
@@ -2060,29 +2061,29 @@ Then, the cancellation propagates back up the tree, allowing each handler to run
 
 <Accordion title="Try out cancellation" icon={"laptop"}>
 
-Start the workflow asynchronously with `/send`:
+Start the workflow asynchronously with the `send` verb:
 <GlobalTabs  className={"hidden-tabs"}>
     <GlobalTab title="TypeScript">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/eve/run/send \
+        curl localhost:8080/restate/send/SignupWithSignalsWorkflow/eve/run \
         --json '{"name": "Eve", "email": "eve@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Java">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/eve/run/send \
+        curl localhost:8080/restate/send/SignupWithSignalsWorkflow/eve/run \
         --json '{"name": "Eve", "email": "eve@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Go">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/eve/Run/send \
+        curl localhost:8080/restate/send/SignupWithSignalsWorkflow/eve/Run \
         --json '{"name": "Eve", "email": "eve@mail.com"}'
         ```
     </GlobalTab>
     <GlobalTab title="Python">
         ```bash
-        curl localhost:8080/SignupWithSignalsWorkflow/eve/run/send \
+        curl localhost:8080/restate/send/SignupWithSignalsWorkflow/eve/run \
         --json '{"name": "Eve", "email": "eve@mail.com"}'
         ```
     </GlobalTab>

--- a/docs/tour/workflows.mdx
+++ b/docs/tour/workflows.mdx
@@ -409,7 +409,7 @@ Have a look at the SDK docs to learn how to schedule workflows programmatically 
 If a workflow is already ongoing, you can also attach to it to get the result once it finishes:
 ```bash
 curl localhost:8080/restate/attach \
-  --json '{"type": "workflow", "name": "SignupWorkflow", "key": "johndoe"}'
+  --json '{"target": "workflow", "workflowName": "SignupWorkflow", "workflowKey": "johndoe"}'
 ```
 Have a look at the SDK docs to learn how to attach to workflows programmatically ([TS](/services/invocation/clients/typescript-sdk) / [Java](/services/invocation/clients/java-sdk) / [Go](/services/invocation/clients/go-sdk)).
 </Accordion>

--- a/snippets/ts/src/ai/guides/chat-ui/http_requests.js
+++ b/snippets/ts/src/ai/guides/chat-ui/http_requests.js
@@ -57,7 +57,7 @@ async function main3() {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      type: "idempotency",
+      target: "idempotentInvocation",
       service: "agent",
       handler: "run",
       idempotencyKey,

--- a/snippets/ts/src/ai/guides/chat-ui/http_requests.js
+++ b/snippets/ts/src/ai/guides/chat-ui/http_requests.js
@@ -1,15 +1,15 @@
 async function main() {
   // <start_here>
   // Request-response
-  const response = await fetch("http://localhost:8080/my-agent/run", {
+  const response = await fetch("http://localhost:8080/restate/call/my-agent/run", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ message: "How are you?" }),
   });
   const result = await response.json();
 
-  // Fire-and-forget: add /send to the URL
-  await fetch("http://localhost:8080/my-agent/run/send", {
+  // Fire-and-forget: use the /restate/send/... path
+  await fetch("http://localhost:8080/restate/send/my-agent/run", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ message: "How are you?" }),
@@ -17,7 +17,7 @@ async function main() {
   // <end_here>
 
   // <start_idempotency>
-  await fetch("http://localhost:8080/my-agent/run/send", {
+  await fetch("http://localhost:8080/restate/send/my-agent/run", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -31,7 +31,7 @@ async function main() {
 async function main2() {
   // <start_attach>
   // start the invocation
-  const handle = await fetch("http://localhost:8080/agent/run/send", {
+  const handle = await fetch("http://localhost:8080/restate/send/agent/run", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify("How are you?"),
@@ -40,9 +40,9 @@ async function main2() {
   // retrieve the invocationId
   const { invocationId, status } = await handle.json();
 
-  // retrieve the result
+  // retrieve the result by attaching to the invocation id
   const result = await fetch(
-    `http://localhost:8080/restate/invocation/${invocationId}/attach`,
+    `http://localhost:8080/restate/attach/${invocationId}`,
     { method: "GET" }
   );
   await result.json();
@@ -51,12 +51,18 @@ async function main2() {
 
 async function main3() {
   // <start_attach_idem>
-  // start the invocation with idempotency key
+  // attach via the idempotency key of an earlier invocation
   const idempotencyKey = "abc-123";
-  const result = await fetch(
-    `http://localhost:8080/restate/invocation/agent/run/${idempotencyKey}/attach`,
-    { method: "GET" }
-  );
+  const result = await fetch(`http://localhost:8080/restate/attach`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      type: "idempotency",
+      service: "agent",
+      handler: "run",
+      idempotencyKey,
+    }),
+  });
   await result.json();
   // <end_attach_idem>
 }


### PR DESCRIPTION
Document the new versioned ingress endpoints introduced in v1.7 and
migrate all examples and code snippets to use them.

- Rewrite the HTTP ingress reference page: /restate/call and /restate/send
  URL structure, a new Scopes section (experimental vqueues), and the new
  attach/output/lookup API (by invocation id and by target). Limit-key is
  omitted as it is enterprise-only.
- Globally rewrite unversioned localhost:8080/Service[/key]/handler[/send]
  examples site-wide to /restate/call/... and /restate/send/..., preserving
  keys and query parameters.
- Convert old /restate/invocation/... and /restate/workflow/... attach
  examples to the new GET/POST /restate/attach|output and /restate/lookup.
- Update prose that described the old "/send suffix" pattern.

This fixes #288.