### PR TITLE
[configs] Add the env variables to the server config docs

### DIFF
--- a/docs/references/server-config.mdx
+++ b/docs/references/server-config.mdx
@@ -8,7 +8,7 @@ import Intro from "/snippets/common/default-configuration.mdx"
 
 <Intro />
 
-<ResponseField name="additional-request-headers" type="object | null" post={[]}>
+<ResponseField name="additional-request-headers" type="object | null" post={['env: RESTATE_ADDITIONAL_REQUEST_HEADERS']}>
     Additional request headers: Headers that should be applied to all outgoing requests (HTTP and Lambda).
 Defaults to `x-restate-cluster-name: &lt;cluster name&gt;`.
 
@@ -21,7 +21,7 @@ Use it directly or with `#[serde(with = \"serde_with::As::&lt;serde_with::FromIn
 
     
     <Expandable title="Properties">
-        <ResponseField name="advertised-address" type="string | null" post={[]}>
+        <ResponseField name="advertised-address" type="string | null" post={['env: RESTATE_ADMIN__ADVERTISED_ADDRESS']}>
             Address that other nodes will use to connect to this service.
 
 The full prefix that will be used to advertise this service publicly.
@@ -37,7 +37,7 @@ Examples:
 "http//127.0.0.1:9070/" or "https://my-host/" or "unix:/data/restate-data/admin.sock"
         </ResponseField>
 
-        <ResponseField name="advertised-admin-endpoint" type="string | null" post={[]}>
+        <ResponseField name="advertised-admin-endpoint" type="string | null" post={['env: RESTATE_ADMIN__ADVERTISED_ADMIN_ENDPOINT']}>
             Advertised Admin endpoint: Optional advertised Admin API endpoint.
 [Deprecated] Use `advertised-address` instead.
 
@@ -47,12 +47,12 @@ Examples:
 "http//127.0.0.1:9070/" or "https://my-host/" or "unix:/data/restate-data/admin.sock"
         </ResponseField>
 
-        <ResponseField name="advertised-host" type="string | null" post={[]}>
+        <ResponseField name="advertised-host" type="string | null" post={['env: RESTATE_ADMIN__ADVERTISED_HOST']}>
             Hostname to advertise for this service
 
         </ResponseField>
 
-        <ResponseField name="bind-address" type="string | null" post={[]}>
+        <ResponseField name="bind-address" type="string | null" post={['env: RESTATE_ADMIN__BIND_ADDRESS']}>
             The combination of `bind-ip` and `bind-port` that will be used to bind
 
 This has precedence over `bind-ip` and `bind-port`
@@ -63,17 +63,17 @@ Examples:
 "0.0.0.0:9070" or "127.0.0.1:9070"
         </ResponseField>
 
-        <ResponseField name="bind-ip" type="string | null" post={['format: ip']}>
+        <ResponseField name="bind-ip" type="string | null" post={['format: ip','env: RESTATE_ADMIN__BIND_IP']}>
             Local interface IP address to listen on
 
         </ResponseField>
 
-        <ResponseField name="bind-port" type="integer | null" post={['format: uint16','maximum: 65535']}>
+        <ResponseField name="bind-port" type="integer | null" post={['format: uint16','maximum: 65535','env: RESTATE_ADMIN__BIND_PORT']}>
             Network port to listen on
 
         </ResponseField>
 
-        <ResponseField name="concurrent-api-requests-limit" type="integer | null" post={['default=null','format: uint','minimum: 1']}>
+        <ResponseField name="concurrent-api-requests-limit" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_ADMIN__CONCURRENT_API_REQUESTS_LIMIT']} default="null">
             Concurrency limit for the Admin APIs. Default is unlimited.
 
         </ResponseField>
@@ -91,15 +91,15 @@ These will be used during deployment creation to distinguish between an already 
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="disable-cluster-controller" type="boolean" post={['default=false']}>
+        <ResponseField name="disable-cluster-controller" type="boolean" post={['env: RESTATE_ADMIN__DISABLE_CLUSTER_CONTROLLER']} default="false">
         </ResponseField>
 
-        <ResponseField name="disable-web-ui" type="boolean" post={['default=false']}>
+        <ResponseField name="disable-web-ui" type="boolean" post={['env: RESTATE_ADMIN__DISABLE_WEB_UI']} default="false">
             Disable serving the Restate Web UI on the admin port. Default is `false`.
 
         </ResponseField>
 
-        <ResponseField name="heartbeat-interval" type="string" post={['default="1s 500ms"','minLength: 1']}>
+        <ResponseField name="heartbeat-interval" type="string" post={['minLength: 1','env: RESTATE_ADMIN__HEARTBEAT_INTERVAL']} default="1s 500ms">
             Controller heartbeats: Controls the interval at which cluster controller polls nodes of the cluster.
 
 Examples:
@@ -107,7 +107,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="listen-mode" type="oneOf | null" post={[]}>
+        <ResponseField name="listen-mode" type="oneOf | null" post={['env: RESTATE_ADMIN__LISTEN_MODE']}>
             Listen on unix-sockets, TCP sockets, or both.
 
 The default is to listen on both.
@@ -126,17 +126,17 @@ will create a socket file under the data directory.
 
             
             <Expandable title="Properties">
-                <ResponseField name="memory-size" type="string" post={['default="1.0 GiB"','minLength: 1']}>
+                <ResponseField name="memory-size" type="string" post={['minLength: 1','env: RESTATE_ADMIN__QUERY_ENGINE__MEMORY_SIZE']} default="1.0 GiB">
                     Memory size limit: The total memory in bytes that can be used to preform sql queries
 
                 </ResponseField>
 
-                <ResponseField name="query-parallelism" type="integer | null" post={['default=null','format: uint','minimum: 1']}>
+                <ResponseField name="query-parallelism" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_ADMIN__QUERY_ENGINE__QUERY_PARALLELISM']} default="null">
                     Default query parallelism: The degree of parallelism to use for query execution (Defaults to the number of available cores).
 
                 </ResponseField>
 
-                <ResponseField name="tmp-dir" type="string | null" post={['default=null']}>
+                <ResponseField name="tmp-dir" type="string | null" post={['env: RESTATE_ADMIN__QUERY_ENGINE__TMP_DIR']} default="null">
                     Temp folder to use for spill: The path to spill to
 
                 </ResponseField>
@@ -144,7 +144,7 @@ will create a socket file under the data directory.
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="use-random-ports" type="boolean | null" post={[]}>
+        <ResponseField name="use-random-ports" type="boolean | null" post={['env: RESTATE_ADMIN__USE_RANDOM_PORTS']}>
             Use random ports instead of the default port
 
         </ResponseField>
@@ -152,7 +152,7 @@ will create a socket file under the data directory.
     </Expandable>
 </ResponseField>
 
-<ResponseField name="advertised-address" type="string | null" post={[]}>
+<ResponseField name="advertised-address" type="string | null" post={['env: RESTATE_ADVERTISED_ADDRESS']}>
     Address that other nodes will use to connect to this service.
 
 The full prefix that will be used to advertise this service publicly.
@@ -168,12 +168,12 @@ Examples:
 "http//127.0.0.1:6669/" or "https://my-host/" or "unix:/data/restate-data/tokio.sock"
 </ResponseField>
 
-<ResponseField name="advertised-host" type="string | null" post={[]}>
+<ResponseField name="advertised-host" type="string | null" post={['env: RESTATE_ADVERTISED_HOST']}>
     Hostname to advertise for this service
 
 </ResponseField>
 
-<ResponseField name="auto-provision" type="boolean" post={['default=true']}>
+<ResponseField name="auto-provision" type="boolean" post={['env: RESTATE_AUTO_PROVISION']} default="true">
     Auto cluster provisioning: If true, then this node is allowed to automatically provision as a new cluster.
 This node *must* have an admin role and a new nodes configuration will be created that includes this node.
 
@@ -188,20 +188,20 @@ Default: true
 
 </ResponseField>
 
-<ResponseField name="aws-assume-role-external-id" type="string | null" post={['default=null']}>
+<ResponseField name="aws-assume-role-external-id" type="string | null" post={['env: RESTATE_AWS_ASSUME_ROLE_EXTERNAL_ID']} default="null">
     AssumeRole external ID: An external ID to apply to any AssumeRole operations taken by this client.
 https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
 Can be overridden by the `AWS_EXTERNAL_ID` environment variable.
 
 </ResponseField>
 
-<ResponseField name="aws-profile" type="string | null" post={['default=null']}>
+<ResponseField name="aws-profile" type="string | null" post={['env: RESTATE_AWS_PROFILE']} default="null">
     AWS Profile: Name of the AWS profile to select. Defaults to 'AWS_PROFILE' env var, or otherwise
 the `default` profile.
 
 </ResponseField>
 
-<ResponseField name="base-dir" type="string | null" post={['default=null']}>
+<ResponseField name="base-dir" type="string | null" post={['env: RESTATE_BASE_DIR']} default="null">
     The working directory which this Restate node should use for relative paths. The default is
 `restate-data` under the current working directory.
 
@@ -212,7 +212,7 @@ the `default` profile.
 
     
     <Expandable title="Properties">
-        <ResponseField name="append-retry-max-interval" type="string" post={['default="1s"','minLength: 1']}>
+        <ResponseField name="append-retry-max-interval" type="string" post={['minLength: 1','env: RESTATE_BIFROST__APPEND_RETRY_MAX_INTERVAL']} default="1s">
             Append retry maximum interval: Maximum retry duration used by the exponential backoff mechanism for bifrost appends.
 
 Examples:
@@ -220,7 +220,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="append-retry-min-interval" type="string" post={['default="10ms"','minLength: 1']}>
+        <ResponseField name="append-retry-min-interval" type="string" post={['minLength: 1','env: RESTATE_BIFROST__APPEND_RETRY_MIN_INTERVAL']} default="10ms">
             Append retry minimum interval: Minimum retry duration used by the exponential backoff mechanism for bifrost appends.
 
 Examples:
@@ -228,7 +228,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="auto-recovery-interval" type="string" post={['default="15s"','minLength: 1']}>
+        <ResponseField name="auto-recovery-interval" type="string" post={['minLength: 1','env: RESTATE_BIFROST__AUTO_RECOVERY_INTERVAL']} default="15s">
             Auto recovery threshold: Time interval after which bifrost's auto-recovery mechanism will kick in. This
 is triggered in scenarios where the control plane took too long to complete loglet
 reconfigurations.
@@ -238,7 +238,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="default-provider"  post={['default="replicated"']}>
+        <ResponseField name="default-provider"  post={['env: RESTATE_BIFROST__DEFAULT_PROVIDER']} default="replicated">
             The default kind of loglet to be used: Default: Replicated
 
             
@@ -247,7 +247,7 @@ Examples:
 `log-server` role to run on enough nodes in the cluster.
         </ResponseField>
 
-        <ResponseField name="disable-auto-improvement" type="string" post={['default=false']}>
+        <ResponseField name="disable-auto-improvement" type="string" post={['env: RESTATE_BIFROST__DISABLE_AUTO_IMPROVEMENT']} default="false">
             Disable Automatic Improvement: When enabled, automatic improvement periodically checks with the loglet provider
 if the loglet configuration can be improved by performing a reconfiguration.
 
@@ -256,7 +256,7 @@ of replicas, or for other reasons.
 
         </ResponseField>
 
-        <ResponseField name="local" type="string" post={[]}>
+        <ResponseField name="local" type="string" post={['env: RESTATE_BIFROST__LOCAL']}>
             Configuration of local loglet provider
 
         </ResponseField>
@@ -270,7 +270,7 @@ read operations
             <Expandable title="Option 1: None">
             No retry strategy.
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_BIFROST__READ_RETRY_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -278,7 +278,7 @@ read operations
             <Expandable title="Option 2: Fixed delay">
             Retry with a fixed delay strategy.
 
-                <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_BIFROST__READ_RETRY_POLICY__INTERVAL']}>
                     Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -288,12 +288,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_BIFROST__READ_RETRY_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_BIFROST__READ_RETRY_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -301,12 +301,12 @@ Examples:
             <Expandable title="Option 3: Exponential">
             Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                <ResponseField name="factor" type="number" required post={['format: float']}>
+                <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_BIFROST__READ_RETRY_POLICY__FACTOR']}>
                     Factor: The factor to use to compute the next retry attempt.
 
                 </ResponseField>
 
-                <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_BIFROST__READ_RETRY_POLICY__INITIAL_INTERVAL']}>
                     Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -316,12 +316,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_BIFROST__READ_RETRY_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="max-interval" type="string | null" post={[]}>
+                <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_BIFROST__READ_RETRY_POLICY__MAX_INTERVAL']}>
                     Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -332,13 +332,13 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_BIFROST__READ_RETRY_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="record-cache-memory-size" type="string" post={['default="250.0 MiB"','minLength: 1']}>
+        <ResponseField name="record-cache-memory-size" type="string" post={['minLength: 1','env: RESTATE_BIFROST__RECORD_CACHE_MEMORY_SIZE']} default="250.0 MiB">
             In-memory RecordCache memory limit: Optional size of record cache in bytes.
 If set to 0, record cache will be disabled.
 Defaults: 250MB
@@ -360,7 +360,7 @@ Retry policy for log server RPCs
                     <Expandable title="Option 1: None">
                     No retry strategy.
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_BIFROST__REPLICATED_LOGLET__LOG_SERVER_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -368,7 +368,7 @@ Retry policy for log server RPCs
                     <Expandable title="Option 2: Fixed delay">
                     Retry with a fixed delay strategy.
 
-                        <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                        <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__LOG_SERVER_RETRY_POLICY__INTERVAL']}>
                             Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -378,12 +378,12 @@ Examples:
 
                         </ResponseField>
 
-                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__LOG_SERVER_RETRY_POLICY__MAX_ATTEMPTS']}>
                             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                         </ResponseField>
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_BIFROST__REPLICATED_LOGLET__LOG_SERVER_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -391,12 +391,12 @@ Examples:
                     <Expandable title="Option 3: Exponential">
                     Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                        <ResponseField name="factor" type="number" required post={['format: float']}>
+                        <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_BIFROST__REPLICATED_LOGLET__LOG_SERVER_RETRY_POLICY__FACTOR']}>
                             Factor: The factor to use to compute the next retry attempt.
 
                         </ResponseField>
 
-                        <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                        <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__LOG_SERVER_RETRY_POLICY__INITIAL_INTERVAL']}>
                             Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -406,12 +406,12 @@ Examples:
 
                         </ResponseField>
 
-                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__LOG_SERVER_RETRY_POLICY__MAX_ATTEMPTS']}>
                             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                         </ResponseField>
 
-                        <ResponseField name="max-interval" type="string | null" post={[]}>
+                        <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_BIFROST__REPLICATED_LOGLET__LOG_SERVER_RETRY_POLICY__MAX_INTERVAL']}>
                             Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -422,13 +422,13 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                         </ResponseField>
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_BIFROST__REPLICATED_LOGLET__LOG_SERVER_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
                 </ResponseField>
 
-                <ResponseField name="log-server-rpc-timeout" type="string" post={['default="2s"','minLength: 1']}>
+                <ResponseField name="log-server-rpc-timeout" type="string" post={['minLength: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__LOG_SERVER_RPC_TIMEOUT']} default="2s">
                     Non-zero human-readable duration: Log Server RPC timeout
 
 Timeout waiting on log server response
@@ -438,7 +438,7 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="maximum-inflight-records" type="integer" post={['default=1000','format: uint','minimum: 1']}>
+                <ResponseField name="maximum-inflight-records" type="integer" post={['format: uint','minimum: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__MAXIMUM_INFLIGHT_RECORDS']} default="1000">
                     Maximum number of inflight records sequencer can accept
 
 Once this maximum is hit, sequencer will induce back pressure
@@ -448,7 +448,7 @@ Note that this will be increased to fit the biggest batch of records being enque
 
                 </ResponseField>
 
-                <ResponseField name="read-batch-size" type="string" post={['default="32.0 KiB"','minLength: 1']}>
+                <ResponseField name="read-batch-size" type="string" post={['minLength: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__READ_BATCH_SIZE']} default="32.0 KiB">
                     Limits memory per remote batch read: When reading from a log-server, the server stops reading if the next record will tip over the
 total number of bytes allowed in this configuration option.
 
@@ -457,7 +457,7 @@ read even if that record exceeds the stated budget.
 
                 </ResponseField>
 
-                <ResponseField name="readahead-records" type="integer" post={['default=20','format: uint16','minimum: 1','maximum: 65535']}>
+                <ResponseField name="readahead-records" type="integer" post={['format: uint16','minimum: 1','maximum: 65535','env: RESTATE_BIFROST__REPLICATED_LOGLET__READAHEAD_RECORDS']} default="20">
                     Maximum number of records to prefetch from log servers
 
 The number of records bifrost will attempt to prefetch from replicated loglet's log-servers
@@ -466,7 +466,7 @@ that are not co-located with the loglet sequencer (i.e. partition processor foll
 
                 </ResponseField>
 
-                <ResponseField name="readahead-trigger-ratio" type="number" post={['default=0.5','format: float']}>
+                <ResponseField name="readahead-trigger-ratio" type="number" post={['format: float','env: RESTATE_BIFROST__REPLICATED_LOGLET__READAHEAD_TRIGGER_RATIO']} default="0.5">
                     Trigger to prefetch more records
 
 When read-ahead is used (readahead-records), this value (percentage in float) will determine when
@@ -486,7 +486,7 @@ Value must be between 0 and 1. It will be clamped at `1.0`.
 
                 </ResponseField>
 
-                <ResponseField name="sequencer-inactivity-timeout" type="string" post={['default="15s"','minLength: 1']}>
+                <ResponseField name="sequencer-inactivity-timeout" type="string" post={['minLength: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__SEQUENCER_INACTIVITY_TIMEOUT']} default="15s">
                     Non-zero human-readable duration: Sequencer inactivity timeout
 
 The sequencer is allowed to consider itself quiescent if it did not commit records for this period of time.
@@ -509,7 +509,7 @@ Backoff introduced when sequencer fail to find a suitable spread of log servers
                     <Expandable title="Option 1: None">
                     No retry strategy.
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_BIFROST__REPLICATED_LOGLET__SEQUENCER_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -517,7 +517,7 @@ Backoff introduced when sequencer fail to find a suitable spread of log servers
                     <Expandable title="Option 2: Fixed delay">
                     Retry with a fixed delay strategy.
 
-                        <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                        <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__SEQUENCER_RETRY_POLICY__INTERVAL']}>
                             Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -527,12 +527,12 @@ Examples:
 
                         </ResponseField>
 
-                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__SEQUENCER_RETRY_POLICY__MAX_ATTEMPTS']}>
                             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                         </ResponseField>
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_BIFROST__REPLICATED_LOGLET__SEQUENCER_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -540,12 +540,12 @@ Examples:
                     <Expandable title="Option 3: Exponential">
                     Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                        <ResponseField name="factor" type="number" required post={['format: float']}>
+                        <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_BIFROST__REPLICATED_LOGLET__SEQUENCER_RETRY_POLICY__FACTOR']}>
                             Factor: The factor to use to compute the next retry attempt.
 
                         </ResponseField>
 
-                        <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                        <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__SEQUENCER_RETRY_POLICY__INITIAL_INTERVAL']}>
                             Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -555,12 +555,12 @@ Examples:
 
                         </ResponseField>
 
-                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_BIFROST__REPLICATED_LOGLET__SEQUENCER_RETRY_POLICY__MAX_ATTEMPTS']}>
                             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                         </ResponseField>
 
-                        <ResponseField name="max-interval" type="string | null" post={[]}>
+                        <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_BIFROST__REPLICATED_LOGLET__SEQUENCER_RETRY_POLICY__MAX_INTERVAL']}>
                             Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -571,7 +571,7 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                         </ResponseField>
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_BIFROST__REPLICATED_LOGLET__SEQUENCER_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -580,7 +580,7 @@ Examples:
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="seal-retry-interval" type="string" post={['default="2s"','minLength: 1']}>
+        <ResponseField name="seal-retry-interval" type="string" post={['minLength: 1','env: RESTATE_BIFROST__SEAL_RETRY_INTERVAL']} default="2s">
             Seal retry interval: Interval to wait between retries of loglet seal failures
 
 Examples:
@@ -591,7 +591,7 @@ Examples:
     </Expandable>
 </ResponseField>
 
-<ResponseField name="bind-address" type="string | null" post={[]}>
+<ResponseField name="bind-address" type="string | null" post={['env: RESTATE_BIND_ADDRESS']}>
     The combination of `bind-ip` and `bind-port` that will be used to bind
 
 This has precedence over `bind-ip` and `bind-port`
@@ -602,23 +602,23 @@ Examples:
 "0.0.0.0:6669" or "127.0.0.1:6669"
 </ResponseField>
 
-<ResponseField name="bind-ip" type="string | null" post={['format: ip']}>
+<ResponseField name="bind-ip" type="string | null" post={['format: ip','env: RESTATE_BIND_IP']}>
     Local interface IP address to listen on
 
 </ResponseField>
 
-<ResponseField name="bind-port" type="integer | null" post={['format: uint16','maximum: 65535']}>
+<ResponseField name="bind-port" type="integer | null" post={['format: uint16','maximum: 65535','env: RESTATE_BIND_PORT']}>
     Network port to listen on
 
 </ResponseField>
 
-<ResponseField name="cluster-name" type="string" post={['default="localcluster"']}>
+<ResponseField name="cluster-name" type="string" post={['env: RESTATE_CLUSTER_NAME']} default="localcluster">
     Cluster name: A unique identifier for the cluster. All nodes in the same cluster should
 have the same.
 
 </ResponseField>
 
-<ResponseField name="connect-timeout" type="string" post={['default="10s"','minLength: 1']}>
+<ResponseField name="connect-timeout" type="string" post={['minLength: 1','env: RESTATE_CONNECT_TIMEOUT']} default="10s">
     Connect timeout: How long to wait for a TCP connection to be established before considering
 it a failed attempt.
 
@@ -627,7 +627,7 @@ Examples:
 
 </ResponseField>
 
-<ResponseField name="default-journal-retention" type="string" post={['minLength: 1']}>
+<ResponseField name="default-journal-retention" type="string" post={['minLength: 1','env: RESTATE_DEFAULT_JOURNAL_RETENTION']}>
     Human-readable duration: Duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -635,7 +635,7 @@ Examples:
 
 </ResponseField>
 
-<ResponseField name="default-num-partitions" type="integer" post={['default=24','format: uint16','maximum: 65535']}>
+<ResponseField name="default-num-partitions" type="integer" post={['format: uint16','maximum: 65535','env: RESTATE_DEFAULT_NUM_PARTITIONS']} default="24">
     Partitions: Number of partitions that will be provisioned during initial cluster provisioning.
 partitions are the logical shards used to process messages.
 
@@ -650,7 +650,7 @@ Default: 24
 
 </ResponseField>
 
-<ResponseField name="default-replication" type="string" post={['default=1']}>
+<ResponseField name="default-replication" type="string" post={['env: RESTATE_DEFAULT_REPLICATION']} default="1">
     Default replication factor: Configures the global default replication factor to be used by the the system.
 
 Note that this value only impacts the cluster initial provisioning and will not be respected after
@@ -668,12 +668,12 @@ Check https://docs.restate.dev/services/configuration#retries for more details.
 
     
     <Expandable title="Properties">
-        <ResponseField name="exponentiation-factor" type="number" post={['default=2','format: float']}>
+        <ResponseField name="exponentiation-factor" type="number" post={['format: float','env: RESTATE_DEFAULT_RETRY_POLICY__EXPONENTIATION_FACTOR']} default="2">
             Factor: The factor to use to compute the next retry attempt. Default: `2.0`.
 
         </ResponseField>
 
-        <ResponseField name="initial-interval" type="string" post={['default="500ms"','minLength: 1']}>
+        <ResponseField name="initial-interval" type="string" post={['minLength: 1','env: RESTATE_DEFAULT_RETRY_POLICY__INITIAL_INTERVAL']} default="500ms">
             Initial Interval: Initial interval for the first retry attempt.
 
 Examples:
@@ -681,7 +681,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="max-attempts" type="anyOf" post={['default=70']}>
+        <ResponseField name="max-attempts" type="anyOf" post={['env: RESTATE_DEFAULT_RETRY_POLICY__MAX_ATTEMPTS']} default="70">
             Max attempts: Number of maximum attempts (including the initial) before giving up.
 No retries if set to 1.
 
@@ -690,7 +690,7 @@ No retries if set to 1.
             - `Option 2: Bounded number of retries.` : Bounded number of retries.
         </ResponseField>
 
-        <ResponseField name="max-interval" type="string" post={['default="1m"','minLength: 1']}>
+        <ResponseField name="max-interval" type="string" post={['minLength: 1','env: RESTATE_DEFAULT_RETRY_POLICY__MAX_INTERVAL']} default="1m">
             Max interval: Maximum interval between retries.
 
 Examples:
@@ -698,7 +698,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="on-max-attempts"  post={['default="pause"']}>
+        <ResponseField name="on-max-attempts"  post={['env: RESTATE_DEFAULT_RETRY_POLICY__ON_MAX_ATTEMPTS']} default="pause">
             On max attempts: Behavior when max attempts are reached.
 
 Set to `pause` to pause invocations when max attempts are reached.
@@ -714,24 +714,24 @@ For more details about the invocation lifecycle, check https://docs.restate.dev/
     </Expandable>
 </ResponseField>
 
-<ResponseField name="default-thread-pool-size" type="integer | null" post={['default=null','format: uint']}>
+<ResponseField name="default-thread-pool-size" type="integer | null" post={['format: uint','env: RESTATE_DEFAULT_THREAD_POOL_SIZE']} default="null">
     Default async runtime thread pool: Size of the default thread pool used to perform internal tasks.
 If not set, it defaults to the number of CPU cores.
 
 </ResponseField>
 
-<ResponseField name="disable-prometheus" type="boolean" post={['default=false']}>
+<ResponseField name="disable-prometheus" type="boolean" post={['env: RESTATE_DISABLE_PROMETHEUS']} default="false">
     Disable prometheus metric recording and reporting. Default is `false`.
 
 </ResponseField>
 
-<ResponseField name="disable-telemetry" type="boolean" post={['default=false']}>
+<ResponseField name="disable-telemetry" type="boolean" post={['env: RESTATE_DISABLE_TELEMETRY']} default="false">
     Disable telemetry: Restate uses Scarf to collect anonymous usage data to help us understand how the software is being used.
 You can set this flag to true to disable this collection. It can also be set with the environment variable DO_NOT_TRACK=1.
 
 </ResponseField>
 
-<ResponseField name="experimental-kafka-batch-ingestion" type="boolean" post={['default=false']}>
+<ResponseField name="experimental-kafka-batch-ingestion" type="boolean" post={['env: RESTATE_EXPERIMENTAL_KAFKA_BATCH_INGESTION']} default="false">
     Experimental Kafka batch ingestion: Use the new experimental kafka ingestion path which leverages batching
 for a faster kafka ingestion.
 
@@ -743,7 +743,7 @@ Defaults to `false` in v1.6.
 
 </ResponseField>
 
-<ResponseField name="experimental-shuffler-batch-ingestion" type="boolean" post={['default=false']}>
+<ResponseField name="experimental-shuffler-batch-ingestion" type="boolean" post={['env: RESTATE_EXPERIMENTAL_SHUFFLER_BATCH_INGESTION']} default="false">
     Experimental Shuffler batch ingestion: Use the new experimental batch ingestion path.
 
 Set to `true` to enable the experimental ingestion mechanism.
@@ -754,12 +754,12 @@ Defaults to `false` in v1.6.
 
 </ResponseField>
 
-<ResponseField name="force-node-id" type="integer | null" post={['default=null','format: uint32']}>
+<ResponseField name="force-node-id" type="integer | null" post={['format: uint32','env: RESTATE_FORCE_NODE_ID']} default="null">
     If set, the node insists on acquiring this node ID.
 
 </ResponseField>
 
-<ResponseField name="gossip-extras-exchange-frequency" type="integer" post={['default=10','format: uint32','minimum: 1']}>
+<ResponseField name="gossip-extras-exchange-frequency" type="integer" post={['format: uint32','minimum: 1','env: RESTATE_GOSSIP_EXTRAS_EXCHANGE_FREQUENCY']} default="10">
     Gossip extras exchange frequency: In addition to basic health/liveness information, the gossip protocol is used to exchange
 extra information about the roles hosted by this node. For instance, which partitions are
 currently running, their configuration versions, and the durable LSN of the corresponding
@@ -769,18 +769,18 @@ message will contain the extra information about.
 
 </ResponseField>
 
-<ResponseField name="gossip-failure-threshold" type="integer" post={['default=10','format: uint32','minimum: 1']}>
+<ResponseField name="gossip-failure-threshold" type="integer" post={['format: uint32','minimum: 1','env: RESTATE_GOSSIP_FAILURE_THRESHOLD']} default="10">
     Gossip failure threshold: Specifies how many gossip intervals of inactivity need to pass before
 considering a node as dead.
 
 </ResponseField>
 
-<ResponseField name="gossip-fd-stability-threshold" type="integer" post={['default=3','format: uint32','minimum: 1']}>
+<ResponseField name="gossip-fd-stability-threshold" type="integer" post={['format: uint32','minimum: 1','env: RESTATE_GOSSIP_FD_STABILITY_THRESHOLD']} default="3">
     Gossips before failure detector is stable: 
 
 </ResponseField>
 
-<ResponseField name="gossip-loneliness-threshold" type="integer" post={['default=30','format: uint32','minimum: 1']}>
+<ResponseField name="gossip-loneliness-threshold" type="integer" post={['format: uint32','minimum: 1','env: RESTATE_GOSSIP_LONELINESS_THRESHOLD']} default="30">
     Gossip loneliness threshold: How many intervals need to pass without receiving any gossip messages before considering
 this node as potentially isolated/dead. This threshold is used in the case where the node
 can still send gossip messages but did not receive any. This can rarely happen in
@@ -792,14 +792,14 @@ Note: this threshold does not apply to a cluster that's configured with a single
 
 </ResponseField>
 
-<ResponseField name="gossip-num-peers" type="integer" post={['default=2','format: uint32','minimum: 1']}>
+<ResponseField name="gossip-num-peers" type="integer" post={['format: uint32','minimum: 1','env: RESTATE_GOSSIP_NUM_PEERS']} default="2">
     Number of peers to gossip: On every gossip interval, how many peers each node attempts to gossip with. The default is
 optimized for small clusters (less than 5 nodes). On larger clusters, if gossip overhead is noticeable,
 consider reducing this value to 1.
 
 </ResponseField>
 
-<ResponseField name="gossip-suspect-interval" type="string" post={['default="5s"','minLength: 1']}>
+<ResponseField name="gossip-suspect-interval" type="string" post={['minLength: 1','env: RESTATE_GOSSIP_SUSPECT_INTERVAL']} default="5s">
     Human-readable duration: Duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -807,7 +807,7 @@ Examples:
 
 </ResponseField>
 
-<ResponseField name="gossip-tick-interval" type="string" post={['default="100ms"','minLength: 1']}>
+<ResponseField name="gossip-tick-interval" type="string" post={['minLength: 1','env: RESTATE_GOSSIP_TICK_INTERVAL']} default="100ms">
     Gossip tick interval: The interval at which the failure detector will tick. Decrease this value for faster reaction
 to node failures. Note, that every tick comes with an overhead.
 
@@ -816,7 +816,7 @@ Examples:
 
 </ResponseField>
 
-<ResponseField name="gossip-time-skew-threshold" type="string" post={['default="1s"','minLength: 1']}>
+<ResponseField name="gossip-time-skew-threshold" type="string" post={['minLength: 1','env: RESTATE_GOSSIP_TIME_SKEW_THRESHOLD']} default="1s">
     Gossips time skew threshold: The time skew is the maximum acceptable time difference between the local node and the time
 reported by peers via gossip messages. The time skew is also used to ignore gossip messages
 that are too old.
@@ -826,7 +826,7 @@ Examples:
 
 </ResponseField>
 
-<ResponseField name="hlc-max-drift" type="string" post={['default="0s"','minLength: 1']}>
+<ResponseField name="hlc-max-drift" type="string" post={['minLength: 1','env: RESTATE_HLC_MAX_DRIFT']} default="0s">
     Human-readable duration: Duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -840,7 +840,7 @@ If unset, HTTP/2 keep-alive are disabled.
 
     
     <Expandable title="Properties">
-        <ResponseField name="interval" type="string" post={['default="40s"','minLength: 1']}>
+        <ResponseField name="interval" type="string" post={['minLength: 1','env: RESTATE_HTTP_KEEP_ALIVE_OPTIONS__INTERVAL']} default="40s">
             HTTP/2 Keep-alive interval: Sets an interval for HTTP/2 PING frames should be sent to keep a
 connection alive.
 
@@ -851,7 +851,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="timeout" type="string" post={['default="20s"','minLength: 1']}>
+        <ResponseField name="timeout" type="string" post={['minLength: 1','env: RESTATE_HTTP_KEEP_ALIVE_OPTIONS__TIMEOUT']} default="20s">
             Timeout: Sets a timeout for receiving an acknowledgement of the keep-alive ping.
 
 If the ping is not acknowledged within the timeout, the connection will
@@ -865,7 +865,7 @@ Examples:
     </Expandable>
 </ResponseField>
 
-<ResponseField name="http-proxy" type="string | null" post={['default=null']}>
+<ResponseField name="http-proxy" type="string | null" post={['env: RESTATE_HTTP_PROXY']} default="null">
     Proxy URI: A URI, such as `http://127.0.0.1:10001`, of a server to which all invocations should be sent, with the `Host` header set to the deployment URI.
 HTTPS proxy URIs are supported, but only HTTP endpoint traffic will be proxied currently.
 Can be overridden by the `HTTP_PROXY` environment variable.
@@ -877,7 +877,7 @@ Can be overridden by the `HTTP_PROXY` environment variable.
 
     
     <Expandable title="Properties">
-        <ResponseField name="advertised-address" type="string | null" post={[]}>
+        <ResponseField name="advertised-address" type="string | null" post={['env: RESTATE_INGRESS__ADVERTISED_ADDRESS']}>
             Address that other nodes will use to connect to this service.
 
 The full prefix that will be used to advertise this service publicly.
@@ -893,12 +893,12 @@ Examples:
 "http//127.0.0.1:8080/" or "https://my-host/" or "unix:/data/restate-data/ingress.sock"
         </ResponseField>
 
-        <ResponseField name="advertised-host" type="string | null" post={[]}>
+        <ResponseField name="advertised-host" type="string | null" post={['env: RESTATE_INGRESS__ADVERTISED_HOST']}>
             Hostname to advertise for this service
 
         </ResponseField>
 
-        <ResponseField name="advertised-ingress-endpoint" type="string | null" post={[]}>
+        <ResponseField name="advertised-ingress-endpoint" type="string | null" post={['env: RESTATE_INGRESS__ADVERTISED_INGRESS_ENDPOINT']}>
             [Deprecated] Use `advertised-address` instead.
 Ingress endpoint that the Web UI should use to interact with.
 
@@ -908,7 +908,7 @@ Examples:
 "http//127.0.0.1:8080/" or "https://my-host/" or "unix:/data/restate-data/ingress.sock"
         </ResponseField>
 
-        <ResponseField name="bind-address" type="string | null" post={[]}>
+        <ResponseField name="bind-address" type="string | null" post={['env: RESTATE_INGRESS__BIND_ADDRESS']}>
             The combination of `bind-ip` and `bind-port` that will be used to bind
 
 This has precedence over `bind-ip` and `bind-port`
@@ -919,17 +919,17 @@ Examples:
 "0.0.0.0:8080" or "127.0.0.1:8080"
         </ResponseField>
 
-        <ResponseField name="bind-ip" type="string | null" post={['format: ip']}>
+        <ResponseField name="bind-ip" type="string | null" post={['format: ip','env: RESTATE_INGRESS__BIND_IP']}>
             Local interface IP address to listen on
 
         </ResponseField>
 
-        <ResponseField name="bind-port" type="integer | null" post={['format: uint16','maximum: 65535']}>
+        <ResponseField name="bind-port" type="integer | null" post={['format: uint16','maximum: 65535','env: RESTATE_INGRESS__BIND_PORT']}>
             Network port to listen on
 
         </ResponseField>
 
-        <ResponseField name="concurrent-api-requests-limit" type="integer | null" post={['default=null','format: uint','minimum: 1']}>
+        <ResponseField name="concurrent-api-requests-limit" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_INGRESS__CONCURRENT_API_REQUESTS_LIMIT']} default="null">
             Concurrency limit: Local concurrency limit to use to limit the amount of concurrent requests. If exceeded,
 the ingress will reply immediately with an appropriate status code. Default is unlimited.
 
@@ -951,7 +951,7 @@ retrying every 2 seconds.
                     <Expandable title="Option 1: None">
                     No retry strategy.
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_INGRESS__INGESTION__CONNECTION_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -959,7 +959,7 @@ retrying every 2 seconds.
                     <Expandable title="Option 2: Fixed delay">
                     Retry with a fixed delay strategy.
 
-                        <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                        <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_INGRESS__INGESTION__CONNECTION_RETRY_POLICY__INTERVAL']}>
                             Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -969,12 +969,12 @@ Examples:
 
                         </ResponseField>
 
-                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_INGRESS__INGESTION__CONNECTION_RETRY_POLICY__MAX_ATTEMPTS']}>
                             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                         </ResponseField>
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_INGRESS__INGESTION__CONNECTION_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -982,12 +982,12 @@ Examples:
                     <Expandable title="Option 3: Exponential">
                     Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                        <ResponseField name="factor" type="number" required post={['format: float']}>
+                        <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_INGRESS__INGESTION__CONNECTION_RETRY_POLICY__FACTOR']}>
                             Factor: The factor to use to compute the next retry attempt.
 
                         </ResponseField>
 
-                        <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                        <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_INGRESS__INGESTION__CONNECTION_RETRY_POLICY__INITIAL_INTERVAL']}>
                             Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -997,12 +997,12 @@ Examples:
 
                         </ResponseField>
 
-                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_INGRESS__INGESTION__CONNECTION_RETRY_POLICY__MAX_ATTEMPTS']}>
                             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                         </ResponseField>
 
-                        <ResponseField name="max-interval" type="string | null" post={[]}>
+                        <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_INGRESS__INGESTION__CONNECTION_RETRY_POLICY__MAX_INTERVAL']}>
                             Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1013,13 +1013,13 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                         </ResponseField>
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_INGRESS__INGESTION__CONNECTION_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
                 </ResponseField>
 
-                <ResponseField name="inflight-memory-budget" type="string" required post={['minLength: 1']}>
+                <ResponseField name="inflight-memory-budget" type="string" required post={['minLength: 1','env: RESTATE_INGRESS__INGESTION__INFLIGHT_MEMORY_BUDGET']}>
                     Inflight Memory Budget: Maximum total size of in-flight ingestion requests in bytes.
 Tune this to your workload so there are enough unpersisted
 requests for efficient batching without exhausting memory.
@@ -1028,7 +1028,7 @@ Defaults to 1 MiB.
 
                 </ResponseField>
 
-                <ResponseField name="request-batch-size" type="string" required post={['minLength: 1']}>
+                <ResponseField name="request-batch-size" type="string" required post={['minLength: 1','env: RESTATE_INGRESS__INGESTION__REQUEST_BATCH_SIZE']}>
                     Request Batch Size: Maximum size of a single ingestion request batch.
 Tune to keep enough requests per batch for
 throughput; overly large batches can increase tail latency.
@@ -1040,7 +1040,7 @@ Defaults to 50 KiB.
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="kafka-clusters" type="array" post={['default=[]']}>
+        <ResponseField name="kafka-clusters" type="array" post={[]} default="[]">
             
             <Expandable title="Array Items">
                 <ResponseField name="item" type="object" post={[]}>
@@ -1070,7 +1070,7 @@ Defaults to 50 KiB.
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="listen-mode" type="oneOf | null" post={[]}>
+        <ResponseField name="listen-mode" type="oneOf | null" post={['env: RESTATE_INGRESS__LISTEN_MODE']}>
             Listen on unix-sockets, TCP sockets, or both.
 
 The default is to listen on both.
@@ -1084,7 +1084,7 @@ will create a socket file under the data directory.
             - `"all"` : [default] Listen on both Unix and TCP sockets
         </ResponseField>
 
-        <ResponseField name="use-random-ports" type="boolean | null" post={[]}>
+        <ResponseField name="use-random-ports" type="boolean | null" post={['env: RESTATE_INGRESS__USE_RANDOM_PORTS']}>
             Use random ports instead of the default port
 
         </ResponseField>
@@ -1092,7 +1092,7 @@ will create a socket file under the data directory.
     </Expandable>
 </ResponseField>
 
-<ResponseField name="initial-max-send-streams" type="integer | null" post={['default=null','format: uint']}>
+<ResponseField name="initial-max-send-streams" type="integer | null" post={['format: uint','env: RESTATE_INITIAL_MAX_SEND_STREAMS']} default="null">
     Initial Max Send Streams: Sets the initial maximum of locally initiated (send) streams.
 
 This value will be overwritten by the value included in the initial
@@ -1105,7 +1105,7 @@ recommended value from HTTP2 specs
 
 </ResponseField>
 
-<ResponseField name="initialization-timeout" type="string" post={['default="5m"','minLength: 1']}>
+<ResponseField name="initialization-timeout" type="string" post={['minLength: 1','env: RESTATE_INITIALIZATION_TIMEOUT']} default="5m">
     Initialization timeout: The timeout until the node gives up joining a cluster and initializing itself.
 
 Examples:
@@ -1113,7 +1113,7 @@ Examples:
 
 </ResponseField>
 
-<ResponseField name="listen-mode" type="oneOf | null" post={[]}>
+<ResponseField name="listen-mode" type="oneOf | null" post={['env: RESTATE_LISTEN_MODE']}>
     Listen on unix-sockets, TCP sockets, or both.
 
 The default is to listen on both.
@@ -1127,7 +1127,7 @@ will create a socket file under the data directory.
     - `"all"` : [default] Listen on both Unix and TCP sockets
 </ResponseField>
 
-<ResponseField name="location" type="string" post={[]}>
+<ResponseField name="location" type="string" post={['env: RESTATE_LOCATION']}>
     Node Location: Setting the location allows Restate to form a tree-like cluster topology.
 The value is written in the format of \"region[.zone]\" to assign this node
 to a specific region, or to a zone within a region.
@@ -1149,18 +1149,18 @@ Examples
 
 </ResponseField>
 
-<ResponseField name="log-disable-ansi-codes" type="boolean" post={['default=false']}>
+<ResponseField name="log-disable-ansi-codes" type="boolean" post={['env: RESTATE_LOG_DISABLE_ANSI_CODES']} default="false">
     Disable ANSI in log output: Disable ANSI terminal codes for logs. This is useful when the log collector doesn't support processing ANSI terminal codes.
 
 </ResponseField>
 
-<ResponseField name="log-filter" type="string" post={['default="warn,restate=info"']}>
+<ResponseField name="log-filter" type="string" post={['env: RESTATE_LOG_FILTER']} default="warn,restate=info">
     Logging Filter: Log filter configuration. Can be overridden by the `RUST_LOG` environment variable.
 Check the [`RUST_LOG` documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) for more details how to configure it.
 
 </ResponseField>
 
-<ResponseField name="log-format"  post={['default="pretty"']}>
+<ResponseField name="log-format"  post={['env: RESTATE_LOG_FORMAT']} default="pretty">
     Logging format: Format to use when logging.
 
     
@@ -1174,12 +1174,12 @@ Check the [`RUST_LOG` documentation](https://docs.rs/tracing-subscriber/latest/t
 
     
     <Expandable title="Properties">
-        <ResponseField name="incoming-network-queue-length" type="integer" post={['default=1000','format: uint','minimum: 1']}>
+        <ResponseField name="incoming-network-queue-length" type="integer" post={['format: uint','minimum: 1','env: RESTATE_LOG_SERVER__INCOMING_NETWORK_QUEUE_LENGTH']} default="1000">
             The number of messages that can queue up on input network stream while request processor is busy.
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-block-size" type="string | null" post={[]}>
+        <ResponseField name="rocksdb-block-size" type="string | null" post={['env: RESTATE_LOG_SERVER__ROCKSDB_BLOCK_SIZE']}>
             RocksDB block size: Uncompressed block size
 
 Default: 64KiB
@@ -1187,7 +1187,7 @@ Default: 64KiB
             Non-zero human-readable bytes
         </ResponseField>
 
-        <ResponseField name="rocksdb-compaction-readahead-size" type="string | null" post={[]}>
+        <ResponseField name="rocksdb-compaction-readahead-size" type="string | null" post={['env: RESTATE_LOG_SERVER__ROCKSDB_COMPACTION_READAHEAD_SIZE']}>
             RocksDB compaction readahead size in bytes: If non-zero, we perform bigger reads when doing compaction. If you're
 running RocksDB on spinning disks, you should set this to at least 2MB.
 That way RocksDB's compaction is doing sequential instead of random reads.
@@ -1195,12 +1195,12 @@ That way RocksDB's compaction is doing sequential instead of random reads.
             Non-zero human-readable bytes
         </ResponseField>
 
-        <ResponseField name="rocksdb-disable-direct-io-for-flush-and-compactions" type="boolean | null" post={[]}>
+        <ResponseField name="rocksdb-disable-direct-io-for-flush-and-compactions" type="boolean | null" post={['env: RESTATE_LOG_SERVER__ROCKSDB_DISABLE_DIRECT_IO_FOR_FLUSH_AND_COMPACTIONS']}>
             Disable Direct IO for flush and compactions: Use O_DIRECT for writes in background flush and compactions.
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-disable-direct-io-for-reads" type="boolean | null" post={[]}>
+        <ResponseField name="rocksdb-disable-direct-io-for-reads" type="boolean | null" post={['env: RESTATE_LOG_SERVER__ROCKSDB_DISABLE_DIRECT_IO_FOR_READS']}>
             Disable Direct IO for reads: Files will be opened in \"direct I/O\" mode
 which means that data r/w from the disk will not be cached or
 buffered. The hardware buffer of the devices may however still
@@ -1208,33 +1208,33 @@ be used. Memory mapped files are not impacted by these parameters.
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-disable-statistics" type="boolean | null" post={[]}>
+        <ResponseField name="rocksdb-disable-statistics" type="boolean | null" post={['env: RESTATE_LOG_SERVER__ROCKSDB_DISABLE_STATISTICS']}>
             Disable rocksdb statistics collection
 
 Default: False (statistics enabled)
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-disable-wal" type="boolean | null" post={[]}>
+        <ResponseField name="rocksdb-disable-wal" type="boolean | null" post={['env: RESTATE_LOG_SERVER__ROCKSDB_DISABLE_WAL']}>
             Disable WAL: The default depends on the different rocksdb use-cases at Restate.
 
 Supports hot-reloading (Partial / Bifrost only)
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-disable-wal-fsync" type="boolean" post={['default=false']}>
+        <ResponseField name="rocksdb-disable-wal-fsync" type="boolean" post={['env: RESTATE_LOG_SERVER__ROCKSDB_DISABLE_WAL_FSYNC']} default="false">
             Disable fsync of WAL on every batch
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-log-keep-file-num" type="integer | null" post={['default=null','format: uint']}>
+        <ResponseField name="rocksdb-log-keep-file-num" type="integer | null" post={['format: uint','env: RESTATE_LOG_SERVER__ROCKSDB_LOG_KEEP_FILE_NUM']} default="null">
             RocksDB log keep file num: Number of info LOG files to keep
 
 Default: 1
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-log-level" type="string | null" post={['default=null']}>
+        <ResponseField name="rocksdb-log-level" type="string | null" post={['env: RESTATE_LOG_SERVER__ROCKSDB_LOG_LEVEL']} default="null">
             RocksDB log level: Verbosity of the LOG.
 
 Default: \"error\"
@@ -1242,7 +1242,7 @@ Default: \"error\"
             Verbosity of the LOG.
         </ResponseField>
 
-        <ResponseField name="rocksdb-log-max-file-size" type="string | null" post={['default=null']}>
+        <ResponseField name="rocksdb-log-max-file-size" type="string | null" post={['env: RESTATE_LOG_SERVER__ROCKSDB_LOG_MAX_FILE_SIZE']} default="null">
             RocksDB log max file size: Max size of info LOG file
 
 Default: 64MB
@@ -1250,12 +1250,12 @@ Default: 64MB
             Non-zero human-readable bytes
         </ResponseField>
 
-        <ResponseField name="rocksdb-max-background-jobs" type="integer | null" post={['format: uint32','minimum: 1']}>
+        <ResponseField name="rocksdb-max-background-jobs" type="integer | null" post={['format: uint32','minimum: 1','env: RESTATE_LOG_SERVER__ROCKSDB_MAX_BACKGROUND_JOBS']}>
             RocksDB max background jobs (flushes and compactions): Default: the number of CPU cores on this node.
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-max-sub-compactions" type="integer" post={['default=0','format: uint32']}>
+        <ResponseField name="rocksdb-max-sub-compactions" type="integer" post={['format: uint32','env: RESTATE_LOG_SERVER__ROCKSDB_MAX_SUB_COMPACTIONS']} default="0">
             The maximum number of subcompactions to run in parallel.
 
 Setting this to 1 means no sub-compactions are allowed (i.e. only 1 thread will do the compaction).
@@ -1264,7 +1264,7 @@ Default is 0 which maps to floor(number of CPU cores / 2)
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-max-wal-size" type="string" post={['minLength: 1']}>
+        <ResponseField name="rocksdb-max-wal-size" type="string" post={['minLength: 1','env: RESTATE_LOG_SERVER__ROCKSDB_MAX_WAL_SIZE']}>
             Human-readable bytes: The size limit of all WAL files
 
 Use this to limit the size of WAL files. If the size of all WAL files exceeds this limit,
@@ -1280,7 +1280,7 @@ database.
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-memory-budget" type="string | null" post={[]}>
+        <ResponseField name="rocksdb-memory-budget" type="string | null" post={['env: RESTATE_LOG_SERVER__ROCKSDB_MEMORY_BUDGET']}>
             The memory budget for rocksdb memtables in bytes
 
 If this value is set, it overrides the ratio defined in `rocksdb-memory-ratio`.
@@ -1288,7 +1288,7 @@ If this value is set, it overrides the ratio defined in `rocksdb-memory-ratio`.
             Non-zero human-readable bytes
         </ResponseField>
 
-        <ResponseField name="rocksdb-memory-ratio" type="number" post={['default=0.5','format: float']}>
+        <ResponseField name="rocksdb-memory-ratio" type="number" post={['format: float','env: RESTATE_LOG_SERVER__ROCKSDB_MEMORY_RATIO']} default="0.5">
             The memory budget for rocksdb memtables as ratio
 
 This defines the total memory for rocksdb as a ratio of all memory available to the
@@ -1298,7 +1298,7 @@ log-server.
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-statistics-level" type="oneOf | null" post={[]}>
+        <ResponseField name="rocksdb-statistics-level" type="oneOf | null" post={['env: RESTATE_LOG_SERVER__ROCKSDB_STATISTICS_LEVEL']}>
             RocksDB statistics level: StatsLevel can be used to reduce statistics overhead by skipping certain
 types of stats in the stats collection process.
 
@@ -1317,7 +1317,7 @@ If getting time is expensive on the platform to run, it can
 reduce scalability to more threads, especially for writes.
         </ResponseField>
 
-        <ResponseField name="writer-batch-commit-count" type="integer" post={['default=5000','format: uint']}>
+        <ResponseField name="writer-batch-commit-count" type="integer" post={['format: uint','env: RESTATE_LOG_SERVER__WRITER_BATCH_COMMIT_COUNT']} default="5000">
             Trigger a commit when the batch size exceeds this threshold.
 
 Set to 0 or 1 to commit the write batch on every command.
@@ -1327,7 +1327,7 @@ Set to 0 or 1 to commit the write batch on every command.
     </Expandable>
 </ResponseField>
 
-<ResponseField name="max-journal-retention" type="string | null" post={[]}>
+<ResponseField name="max-journal-retention" type="string | null" post={['env: RESTATE_MAX_JOURNAL_RETENTION']}>
     Maximum journal retention duration that can be configured.
 When discovering a service deployment, or when modifying the journal retention using the Admin API, the given value will be clamped.
 
@@ -1339,7 +1339,7 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
 </ResponseField>
 
-<ResponseField name="max-retry-policy-max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+<ResponseField name="max-retry-policy-max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_MAX_RETRY_POLICY_MAX_ATTEMPTS']}>
     Max configurable value for retry policy max attempts: Maximum max attempts configurable in an invocation retry policy.
 When discovering a service deployment with configured retry policies, or when modifying the invocation retry policy using the Admin API, the given value will be clamped.
 
@@ -1364,7 +1364,7 @@ When discovering a service deployment with configured retry policies, or when mo
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="type" type="string" post={[]}>
+        <ResponseField name="type" type="string" post={['env: RESTATE_METADATA_CLIENT__TYPE']}>
         </ResponseField>
 
         <ResponseField name="backoff-policy"  post={[]}>
@@ -1375,7 +1375,7 @@ When discovering a service deployment with configured retry policies, or when mo
             <Expandable title="Option 1: None">
             No retry strategy.
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -1383,7 +1383,7 @@ When discovering a service deployment with configured retry policies, or when mo
             <Expandable title="Option 2: Fixed delay">
             Retry with a fixed delay strategy.
 
-                <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__INTERVAL']}>
                     Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1393,12 +1393,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -1406,12 +1406,12 @@ Examples:
             <Expandable title="Option 3: Exponential">
             Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                <ResponseField name="factor" type="number" required post={['format: float']}>
+                <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__FACTOR']}>
                     Factor: The factor to use to compute the next retry attempt.
 
                 </ResponseField>
 
-                <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__INITIAL_INTERVAL']}>
                     Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1421,12 +1421,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="max-interval" type="string | null" post={[]}>
+                <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__MAX_INTERVAL']}>
                     Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1437,13 +1437,13 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="connect-timeout" type="string" post={['default="3s"','minLength: 1']}>
+        <ResponseField name="connect-timeout" type="string" post={['minLength: 1','env: RESTATE_METADATA_CLIENT__CONNECT_TIMEOUT']} default="3s">
             Connect timeout: TCP connection timeout for connecting to the metadata store.
 
 Examples:
@@ -1451,7 +1451,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="keep-alive-interval" type="string" post={['default="5s"','minLength: 1']}>
+        <ResponseField name="keep-alive-interval" type="string" post={['minLength: 1','env: RESTATE_METADATA_CLIENT__KEEP_ALIVE_INTERVAL']} default="5s">
             Metadata Store Keep Alive Interval: Non-zero duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -1459,7 +1459,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="keep-alive-timeout" type="string" post={['default="5s"','minLength: 1']}>
+        <ResponseField name="keep-alive-timeout" type="string" post={['minLength: 1','env: RESTATE_METADATA_CLIENT__KEEP_ALIVE_TIMEOUT']} default="5s">
             Metadata Store Keep Alive Timeout: Non-zero duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -1467,7 +1467,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="message-size-limit" type="string | null" post={[]}>
+        <ResponseField name="message-size-limit" type="string | null" post={['env: RESTATE_METADATA_CLIENT__MESSAGE_SIZE_LIMIT']}>
             Metadata Network Message Size: Maximum size of network messages that metadata client can receive from a metadata server.
 
 If unset, defaults to `networking.message-size-limit`. If set, it will be clamped at
@@ -1481,12 +1481,12 @@ over the cluster internal network.
 <Expandable title="Option 2: Store metadata on an external etcd cluster.
 
 The addresses are formatted as `host:port`">
-        <ResponseField name="addresses" type="string" post={[]}>
+        <ResponseField name="addresses" type="string" post={['env: RESTATE_METADATA_CLIENT__ADDRESSES']}>
             Etcd cluster node address list: 
 
         </ResponseField>
 
-        <ResponseField name="type" type="string" post={[]}>
+        <ResponseField name="type" type="string" post={['env: RESTATE_METADATA_CLIENT__TYPE']}>
         </ResponseField>
 
         <ResponseField name="backoff-policy"  post={[]}>
@@ -1497,7 +1497,7 @@ The addresses are formatted as `host:port`">
             <Expandable title="Option 1: None">
             No retry strategy.
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -1505,7 +1505,7 @@ The addresses are formatted as `host:port`">
             <Expandable title="Option 2: Fixed delay">
             Retry with a fixed delay strategy.
 
-                <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__INTERVAL']}>
                     Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1515,12 +1515,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -1528,12 +1528,12 @@ Examples:
             <Expandable title="Option 3: Exponential">
             Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                <ResponseField name="factor" type="number" required post={['format: float']}>
+                <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__FACTOR']}>
                     Factor: The factor to use to compute the next retry attempt.
 
                 </ResponseField>
 
-                <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__INITIAL_INTERVAL']}>
                     Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1543,12 +1543,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="max-interval" type="string | null" post={[]}>
+                <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__MAX_INTERVAL']}>
                     Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1559,13 +1559,13 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="connect-timeout" type="string" post={['default="3s"','minLength: 1']}>
+        <ResponseField name="connect-timeout" type="string" post={['minLength: 1','env: RESTATE_METADATA_CLIENT__CONNECT_TIMEOUT']} default="3s">
             Connect timeout: TCP connection timeout for connecting to the metadata store.
 
 Examples:
@@ -1573,7 +1573,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="keep-alive-interval" type="string" post={['default="5s"','minLength: 1']}>
+        <ResponseField name="keep-alive-interval" type="string" post={['minLength: 1','env: RESTATE_METADATA_CLIENT__KEEP_ALIVE_INTERVAL']} default="5s">
             Metadata Store Keep Alive Interval: Non-zero duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -1581,7 +1581,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="keep-alive-timeout" type="string" post={['default="5s"','minLength: 1']}>
+        <ResponseField name="keep-alive-timeout" type="string" post={['minLength: 1','env: RESTATE_METADATA_CLIENT__KEEP_ALIVE_TIMEOUT']} default="5s">
             Metadata Store Keep Alive Timeout: Non-zero duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -1589,7 +1589,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="message-size-limit" type="string | null" post={[]}>
+        <ResponseField name="message-size-limit" type="string | null" post={['env: RESTATE_METADATA_CLIENT__MESSAGE_SIZE_LIMIT']}>
             Metadata Network Message Size: Maximum size of network messages that metadata client can receive from a metadata server.
 
 If unset, defaults to `networking.message-size-limit`. If set, it will be clamped at
@@ -1601,25 +1601,25 @@ over the cluster internal network.
 
     </Expandable>
 <Expandable title="Option 3: Store metadata on an external object store.">
-        <ResponseField name="aws-access-key-id" type="string | null" post={[]}>
+        <ResponseField name="aws-access-key-id" type="string | null" post={['env: RESTATE_METADATA_CLIENT__AWS_ACCESS_KEY_ID']}>
             AWS access key: Username for Minio, or consult the service documentation for other S3-compatible stores.
 
         </ResponseField>
 
-        <ResponseField name="aws-allow-http" type="boolean | null" post={[]}>
+        <ResponseField name="aws-allow-http" type="boolean | null" post={['env: RESTATE_METADATA_CLIENT__AWS_ALLOW_HTTP']}>
             Allow insecure HTTP: Allow plain HTTP to be used with the object store endpoint. Required when the endpoint URL
 that isn't using HTTPS.
 
         </ResponseField>
 
-        <ResponseField name="aws-endpoint-url" type="string | null" post={[]}>
+        <ResponseField name="aws-endpoint-url" type="string | null" post={['env: RESTATE_METADATA_CLIENT__AWS_ENDPOINT_URL']}>
             Object store API endpoint URL override: When you use Amazon S3, this is typically inferred from the region and there is no need to
 set it. With other object stores, you will have to provide an appropriate HTTP(S) endpoint.
 If *not* using HTTPS, also set `aws-allow-http` to `true`.
 
         </ResponseField>
 
-        <ResponseField name="aws-profile" type="string | null" post={[]}>
+        <ResponseField name="aws-profile" type="string | null" post={['env: RESTATE_METADATA_CLIENT__AWS_PROFILE']}>
             AWS profile: The AWS configuration profile to use for S3 object store destinations. If you use
 named profiles in your AWS configuration, you can replace all the other settings with
 a single profile reference. See the [AWS documentation on profiles]
@@ -1627,7 +1627,7 @@ a single profile reference. See the [AWS documentation on profiles]
 
         </ResponseField>
 
-        <ResponseField name="aws-region" type="string | null" post={[]}>
+        <ResponseField name="aws-region" type="string | null" post={['env: RESTATE_METADATA_CLIENT__AWS_REGION']}>
             AWS region to use with S3 object store destinations. This may be inferred from the
 environment, for example the current region when running in EC2. Because of the
 request signing algorithm this must have a value. For Minio, you can generally
@@ -1635,12 +1635,12 @@ set this to any string, such as `us-east-1`.
 
         </ResponseField>
 
-        <ResponseField name="aws-secret-access-key" type="string | null" post={[]}>
+        <ResponseField name="aws-secret-access-key" type="string | null" post={['env: RESTATE_METADATA_CLIENT__AWS_SECRET_ACCESS_KEY']}>
             AWS secret key: Password for Minio, or consult the service documentation for other S3-compatible stores.
 
         </ResponseField>
 
-        <ResponseField name="aws-session-token" type="string | null" post={[]}>
+        <ResponseField name="aws-session-token" type="string | null" post={['env: RESTATE_METADATA_CLIENT__AWS_SESSION_TOKEN']}>
             AWS session token: This is only needed with short-term STS session credentials.
 
         </ResponseField>
@@ -1653,7 +1653,7 @@ set this to any string, such as `us-east-1`.
             <Expandable title="Option 1: None">
             No retry strategy.
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__OBJECT_STORE_RETRY_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -1661,7 +1661,7 @@ set this to any string, such as `us-east-1`.
             <Expandable title="Option 2: Fixed delay">
             Retry with a fixed delay strategy.
 
-                <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_METADATA_CLIENT__OBJECT_STORE_RETRY_POLICY__INTERVAL']}>
                     Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1671,12 +1671,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_METADATA_CLIENT__OBJECT_STORE_RETRY_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__OBJECT_STORE_RETRY_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -1684,12 +1684,12 @@ Examples:
             <Expandable title="Option 3: Exponential">
             Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                <ResponseField name="factor" type="number" required post={['format: float']}>
+                <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_METADATA_CLIENT__OBJECT_STORE_RETRY_POLICY__FACTOR']}>
                     Factor: The factor to use to compute the next retry attempt.
 
                 </ResponseField>
 
-                <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_METADATA_CLIENT__OBJECT_STORE_RETRY_POLICY__INITIAL_INTERVAL']}>
                     Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1699,12 +1699,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_METADATA_CLIENT__OBJECT_STORE_RETRY_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="max-interval" type="string | null" post={[]}>
+                <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_METADATA_CLIENT__OBJECT_STORE_RETRY_POLICY__MAX_INTERVAL']}>
                     Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1715,13 +1715,13 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__OBJECT_STORE_RETRY_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="path" type="string" post={[]}>
+        <ResponseField name="path" type="string" post={['env: RESTATE_METADATA_CLIENT__PATH']}>
             Object store path for metadata storage: This location will be used to persist cluster metadata. Takes the form of a URL
 with `s3://` as the protocol and bucket name as the authority, plus an optional
 prefix specified as the path component.
@@ -1730,7 +1730,7 @@ Example: `s3://bucket/prefix`
 
         </ResponseField>
 
-        <ResponseField name="type" type="string" post={[]}>
+        <ResponseField name="type" type="string" post={['env: RESTATE_METADATA_CLIENT__TYPE']}>
         </ResponseField>
 
         <ResponseField name="backoff-policy"  post={[]}>
@@ -1741,7 +1741,7 @@ Example: `s3://bucket/prefix`
             <Expandable title="Option 1: None">
             No retry strategy.
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -1749,7 +1749,7 @@ Example: `s3://bucket/prefix`
             <Expandable title="Option 2: Fixed delay">
             Retry with a fixed delay strategy.
 
-                <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__INTERVAL']}>
                     Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1759,12 +1759,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -1772,12 +1772,12 @@ Examples:
             <Expandable title="Option 3: Exponential">
             Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                <ResponseField name="factor" type="number" required post={['format: float']}>
+                <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__FACTOR']}>
                     Factor: The factor to use to compute the next retry attempt.
 
                 </ResponseField>
 
-                <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__INITIAL_INTERVAL']}>
                     Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1787,12 +1787,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="max-interval" type="string | null" post={[]}>
+                <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__MAX_INTERVAL']}>
                     Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -1803,13 +1803,13 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_METADATA_CLIENT__BACKOFF_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="connect-timeout" type="string" post={['default="3s"','minLength: 1']}>
+        <ResponseField name="connect-timeout" type="string" post={['minLength: 1','env: RESTATE_METADATA_CLIENT__CONNECT_TIMEOUT']} default="3s">
             Connect timeout: TCP connection timeout for connecting to the metadata store.
 
 Examples:
@@ -1817,7 +1817,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="keep-alive-interval" type="string" post={['default="5s"','minLength: 1']}>
+        <ResponseField name="keep-alive-interval" type="string" post={['minLength: 1','env: RESTATE_METADATA_CLIENT__KEEP_ALIVE_INTERVAL']} default="5s">
             Metadata Store Keep Alive Interval: Non-zero duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -1825,7 +1825,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="keep-alive-timeout" type="string" post={['default="5s"','minLength: 1']}>
+        <ResponseField name="keep-alive-timeout" type="string" post={['minLength: 1','env: RESTATE_METADATA_CLIENT__KEEP_ALIVE_TIMEOUT']} default="5s">
             Metadata Store Keep Alive Timeout: Non-zero duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -1833,7 +1833,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="message-size-limit" type="string | null" post={[]}>
+        <ResponseField name="message-size-limit" type="string | null" post={['env: RESTATE_METADATA_CLIENT__MESSAGE_SIZE_LIMIT']}>
             Metadata Network Message Size: Maximum size of network messages that metadata client can receive from a metadata server.
 
 If unset, defaults to `networking.message-size-limit`. If set, it will be clamped at
@@ -1846,7 +1846,7 @@ over the cluster internal network.
     </Expandable>
 </ResponseField>
 
-<ResponseField name="metadata-fetch-from-peer-timeout" type="string" post={['default="3s"','minLength: 1']}>
+<ResponseField name="metadata-fetch-from-peer-timeout" type="string" post={['minLength: 1','env: RESTATE_METADATA_FETCH_FROM_PEER_TIMEOUT']} default="3s">
     Timeout for metadata peer-to-peer fetching: When a node detects that a new metadata version exists, it'll attempt to fetch it from
 its peers. After this timeout duration has passed, the node will attempt to fetch the
 metadata from metadata store as well. This is to ensure that the nodes converge quickly
@@ -1862,7 +1862,7 @@ Examples:
 
     
     <Expandable title="Properties">
-        <ResponseField name="auto-join" type="boolean" post={['default=true']}>
+        <ResponseField name="auto-join" type="boolean" post={['env: RESTATE_METADATA_SERVER__AUTO_JOIN']} default="true">
             Auto join the metadata cluster when being started
 
 Defines whether this node should auto join the metadata store cluster when being started
@@ -1870,13 +1870,13 @@ for the first time.
 
         </ResponseField>
 
-        <ResponseField name="log-trim-threshold" type="integer | null" post={['default=1000','format: uint64']}>
+        <ResponseField name="log-trim-threshold" type="integer | null" post={['format: uint64','env: RESTATE_METADATA_SERVER__LOG_TRIM_THRESHOLD']} default="1000">
             The raft log trim threshold: The threshold for trimming the raft log. The log will be trimmed if the number of apply entries
 exceeds this threshold. The default value is `1000`.
 
         </ResponseField>
 
-        <ResponseField name="raft-election-tick" type="integer" post={['default=10','format: uint','minimum: 1']}>
+        <ResponseField name="raft-election-tick" type="integer" post={['format: uint','minimum: 1','env: RESTATE_METADATA_SERVER__RAFT_ELECTION_TICK']} default="10">
             The number of ticks before triggering an election
 
 The number of ticks before triggering an election. The value must be larger than
@@ -1886,7 +1886,7 @@ value too much can lead to cluster instabilities due to falsely detecting dead l
 
         </ResponseField>
 
-        <ResponseField name="raft-heartbeat-tick" type="integer" post={['default=2','format: uint','minimum: 1']}>
+        <ResponseField name="raft-heartbeat-tick" type="integer" post={['format: uint','minimum: 1','env: RESTATE_METADATA_SERVER__RAFT_HEARTBEAT_TICK']} default="2">
             The number of ticks before sending a heartbeat
 
 A leader sends heartbeat messages to maintain its leadership every heartbeat ticks.
@@ -1894,7 +1894,7 @@ Decrease this value to send heartbeats more often.
 
         </ResponseField>
 
-        <ResponseField name="raft-tick-interval" type="string" post={['default="100ms"','minLength: 1']}>
+        <ResponseField name="raft-tick-interval" type="string" post={['minLength: 1','env: RESTATE_METADATA_SERVER__RAFT_TICK_INTERVAL']} default="100ms">
             Non-zero human-readable duration: The raft tick interval
 
 The interval at which the raft node will tick. Decrease this value in order to let the Raft
@@ -1907,14 +1907,14 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="request-queue-length" type="integer" post={['default=32','format: uint','minimum: 1']}>
+        <ResponseField name="request-queue-length" type="integer" post={['format: uint','minimum: 1','env: RESTATE_METADATA_SERVER__REQUEST_QUEUE_LENGTH']} default="32">
             Limit number of in-flight requests
 
 Number of in-flight metadata store requests.
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-block-size" type="string | null" post={[]}>
+        <ResponseField name="rocksdb-block-size" type="string | null" post={['env: RESTATE_METADATA_SERVER__ROCKSDB_BLOCK_SIZE']}>
             RocksDB block size: Uncompressed block size
 
 Default: 64KiB
@@ -1922,7 +1922,7 @@ Default: 64KiB
             Non-zero human-readable bytes
         </ResponseField>
 
-        <ResponseField name="rocksdb-compaction-readahead-size" type="string | null" post={[]}>
+        <ResponseField name="rocksdb-compaction-readahead-size" type="string | null" post={['env: RESTATE_METADATA_SERVER__ROCKSDB_COMPACTION_READAHEAD_SIZE']}>
             RocksDB compaction readahead size in bytes: If non-zero, we perform bigger reads when doing compaction. If you're
 running RocksDB on spinning disks, you should set this to at least 2MB.
 That way RocksDB's compaction is doing sequential instead of random reads.
@@ -1930,12 +1930,12 @@ That way RocksDB's compaction is doing sequential instead of random reads.
             Non-zero human-readable bytes
         </ResponseField>
 
-        <ResponseField name="rocksdb-disable-direct-io-for-flush-and-compactions" type="boolean | null" post={[]}>
+        <ResponseField name="rocksdb-disable-direct-io-for-flush-and-compactions" type="boolean | null" post={['env: RESTATE_METADATA_SERVER__ROCKSDB_DISABLE_DIRECT_IO_FOR_FLUSH_AND_COMPACTIONS']}>
             Disable Direct IO for flush and compactions: Use O_DIRECT for writes in background flush and compactions.
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-disable-direct-io-for-reads" type="boolean | null" post={[]}>
+        <ResponseField name="rocksdb-disable-direct-io-for-reads" type="boolean | null" post={['env: RESTATE_METADATA_SERVER__ROCKSDB_DISABLE_DIRECT_IO_FOR_READS']}>
             Disable Direct IO for reads: Files will be opened in \"direct I/O\" mode
 which means that data r/w from the disk will not be cached or
 buffered. The hardware buffer of the devices may however still
@@ -1943,28 +1943,28 @@ be used. Memory mapped files are not impacted by these parameters.
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-disable-statistics" type="boolean | null" post={[]}>
+        <ResponseField name="rocksdb-disable-statistics" type="boolean | null" post={['env: RESTATE_METADATA_SERVER__ROCKSDB_DISABLE_STATISTICS']}>
             Disable rocksdb statistics collection
 
 Default: False (statistics enabled)
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-disable-wal" type="boolean | null" post={[]}>
+        <ResponseField name="rocksdb-disable-wal" type="boolean | null" post={['env: RESTATE_METADATA_SERVER__ROCKSDB_DISABLE_WAL']}>
             Disable WAL: The default depends on the different rocksdb use-cases at Restate.
 
 Supports hot-reloading (Partial / Bifrost only)
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-log-keep-file-num" type="integer | null" post={['default=null','format: uint']}>
+        <ResponseField name="rocksdb-log-keep-file-num" type="integer | null" post={['format: uint','env: RESTATE_METADATA_SERVER__ROCKSDB_LOG_KEEP_FILE_NUM']} default="null">
             RocksDB log keep file num: Number of info LOG files to keep
 
 Default: 1
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-log-level" type="string | null" post={['default=null']}>
+        <ResponseField name="rocksdb-log-level" type="string | null" post={['env: RESTATE_METADATA_SERVER__ROCKSDB_LOG_LEVEL']} default="null">
             RocksDB log level: Verbosity of the LOG.
 
 Default: \"error\"
@@ -1972,7 +1972,7 @@ Default: \"error\"
             Verbosity of the LOG.
         </ResponseField>
 
-        <ResponseField name="rocksdb-log-max-file-size" type="string | null" post={['default=null']}>
+        <ResponseField name="rocksdb-log-max-file-size" type="string | null" post={['env: RESTATE_METADATA_SERVER__ROCKSDB_LOG_MAX_FILE_SIZE']} default="null">
             RocksDB log max file size: Max size of info LOG file
 
 Default: 64MB
@@ -1980,12 +1980,12 @@ Default: 64MB
             Non-zero human-readable bytes
         </ResponseField>
 
-        <ResponseField name="rocksdb-max-background-jobs" type="integer | null" post={['format: uint32','minimum: 1']}>
+        <ResponseField name="rocksdb-max-background-jobs" type="integer | null" post={['format: uint32','minimum: 1','env: RESTATE_METADATA_SERVER__ROCKSDB_MAX_BACKGROUND_JOBS']}>
             RocksDB max background jobs (flushes and compactions): Default: the number of CPU cores on this node.
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-memory-budget" type="string | null" post={[]}>
+        <ResponseField name="rocksdb-memory-budget" type="string | null" post={['env: RESTATE_METADATA_SERVER__ROCKSDB_MEMORY_BUDGET']}>
             The memory budget for rocksdb memtables in bytes
 
 If this value is set, it overrides the ratio defined in `rocksdb-memory-ratio`.
@@ -1993,7 +1993,7 @@ If this value is set, it overrides the ratio defined in `rocksdb-memory-ratio`.
             Non-zero human-readable bytes
         </ResponseField>
 
-        <ResponseField name="rocksdb-memory-ratio" type="number" post={['default=0.009999999776482582','format: float']}>
+        <ResponseField name="rocksdb-memory-ratio" type="number" post={['format: float','env: RESTATE_METADATA_SERVER__ROCKSDB_MEMORY_RATIO']} default="0.009999999776482582">
             The memory budget for rocksdb memtables as ratio
 
 This defines the total memory for rocksdb as a ratio of all memory available to memtables
@@ -2001,7 +2001,7 @@ This defines the total memory for rocksdb as a ratio of all memory available to 
 
         </ResponseField>
 
-        <ResponseField name="rocksdb-statistics-level" type="oneOf | null" post={[]}>
+        <ResponseField name="rocksdb-statistics-level" type="oneOf | null" post={['env: RESTATE_METADATA_SERVER__ROCKSDB_STATISTICS_LEVEL']}>
             RocksDB statistics level: StatsLevel can be used to reduce statistics overhead by skipping certain
 types of stats in the stats collection process.
 
@@ -2020,7 +2020,7 @@ If getting time is expensive on the platform to run, it can
 reduce scalability to more threads, especially for writes.
         </ResponseField>
 
-        <ResponseField name="status-update-interval" type="string" post={['default="5s"','minLength: 1']}>
+        <ResponseField name="status-update-interval" type="string" post={['minLength: 1','env: RESTATE_METADATA_SERVER__STATUS_UPDATE_INTERVAL']} default="5s">
             Non-zero human-readable duration: The status update interval
 
 The interval at which the raft node will update its status. Decrease this value in order to
@@ -2034,7 +2034,7 @@ Examples:
     </Expandable>
 </ResponseField>
 
-<ResponseField name="metadata-update-interval" type="string" post={['default="10s"','minLength: 1']}>
+<ResponseField name="metadata-update-interval" type="string" post={['minLength: 1','env: RESTATE_METADATA_UPDATE_INTERVAL']} default="10s">
     Metadata update interval: The idle time after which the node will check for metadata updates from metadata store.
 This helps the node detect if it has been operating with stale metadata for extended period
 of time, primarily because it didn't interact with other peers in the cluster during that
@@ -2053,7 +2053,7 @@ Examples:
     <Expandable title="Option 1: None">
     No retry strategy.
 
-        <ResponseField name="type" type="string" required post={[]}>
+        <ResponseField name="type" type="string" required post={['env: RESTATE_NETWORK_ERROR_RETRY_POLICY__TYPE']}>
         </ResponseField>
 
     </Expandable>
@@ -2061,7 +2061,7 @@ Examples:
     <Expandable title="Option 2: Fixed delay">
     Retry with a fixed delay strategy.
 
-        <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+        <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_NETWORK_ERROR_RETRY_POLICY__INTERVAL']}>
             Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2071,12 +2071,12 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_NETWORK_ERROR_RETRY_POLICY__MAX_ATTEMPTS']}>
             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
         </ResponseField>
 
-        <ResponseField name="type" type="string" required post={[]}>
+        <ResponseField name="type" type="string" required post={['env: RESTATE_NETWORK_ERROR_RETRY_POLICY__TYPE']}>
         </ResponseField>
 
     </Expandable>
@@ -2084,12 +2084,12 @@ Examples:
     <Expandable title="Option 3: Exponential">
     Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-        <ResponseField name="factor" type="number" required post={['format: float']}>
+        <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_NETWORK_ERROR_RETRY_POLICY__FACTOR']}>
             Factor: The factor to use to compute the next retry attempt.
 
         </ResponseField>
 
-        <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+        <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_NETWORK_ERROR_RETRY_POLICY__INITIAL_INTERVAL']}>
             Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2099,12 +2099,12 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_NETWORK_ERROR_RETRY_POLICY__MAX_ATTEMPTS']}>
             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
         </ResponseField>
 
-        <ResponseField name="max-interval" type="string | null" post={[]}>
+        <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_NETWORK_ERROR_RETRY_POLICY__MAX_INTERVAL']}>
             Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2115,7 +2115,7 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
         </ResponseField>
 
-        <ResponseField name="type" type="string" required post={[]}>
+        <ResponseField name="type" type="string" required post={['env: RESTATE_NETWORK_ERROR_RETRY_POLICY__TYPE']}>
         </ResponseField>
 
     </Expandable>
@@ -2135,7 +2135,7 @@ similar keys are present in other config sections, such as in Service Client opt
             <Expandable title="Option 1: None">
             No retry strategy.
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_NETWORKING__CONNECT_RETRY_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -2143,7 +2143,7 @@ similar keys are present in other config sections, such as in Service Client opt
             <Expandable title="Option 2: Fixed delay">
             Retry with a fixed delay strategy.
 
-                <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_NETWORKING__CONNECT_RETRY_POLICY__INTERVAL']}>
                     Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2153,12 +2153,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_NETWORKING__CONNECT_RETRY_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_NETWORKING__CONNECT_RETRY_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
@@ -2166,12 +2166,12 @@ Examples:
             <Expandable title="Option 3: Exponential">
             Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                <ResponseField name="factor" type="number" required post={['format: float']}>
+                <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_NETWORKING__CONNECT_RETRY_POLICY__FACTOR']}>
                     Factor: The factor to use to compute the next retry attempt.
 
                 </ResponseField>
 
-                <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_NETWORKING__CONNECT_RETRY_POLICY__INITIAL_INTERVAL']}>
                     Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2181,12 +2181,12 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_NETWORKING__CONNECT_RETRY_POLICY__MAX_ATTEMPTS']}>
                     Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                 </ResponseField>
 
-                <ResponseField name="max-interval" type="string | null" post={[]}>
+                <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_NETWORKING__CONNECT_RETRY_POLICY__MAX_INTERVAL']}>
                     Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2197,13 +2197,13 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                 </ResponseField>
 
-                <ResponseField name="type" type="string" required post={[]}>
+                <ResponseField name="type" type="string" required post={['env: RESTATE_NETWORKING__CONNECT_RETRY_POLICY__TYPE']}>
                 </ResponseField>
 
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="connect-timeout" type="string" post={['default="3s"','minLength: 1']}>
+        <ResponseField name="connect-timeout" type="string" post={['minLength: 1','env: RESTATE_NETWORKING__CONNECT_TIMEOUT']} default="3s">
             Connect timeout: TCP connection timeout for Restate cluster node-to-node network connections.
 
 Examples:
@@ -2211,17 +2211,17 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="data-stream-window-size" type="string" post={['default="2.0 MiB"','minLength: 1']}>
+        <ResponseField name="data-stream-window-size" type="string" post={['minLength: 1','env: RESTATE_NETWORKING__DATA_STREAM_WINDOW_SIZE']} default="2.0 MiB">
             Non-zero human-readable bytes
 
         </ResponseField>
 
-        <ResponseField name="disable-compression" type="boolean" post={['default=false']}>
+        <ResponseField name="disable-compression" type="boolean" post={['env: RESTATE_NETWORKING__DISABLE_COMPRESSION']} default="false">
             Disable Compression: Disables Zstd compression for internal gRPC network connections
 
         </ResponseField>
 
-        <ResponseField name="handshake-timeout" type="string" post={['default="3s"','minLength: 1']}>
+        <ResponseField name="handshake-timeout" type="string" post={['minLength: 1','env: RESTATE_NETWORKING__HANDSHAKE_TIMEOUT']} default="3s">
             Handshake timeout: Timeout for receiving a handshake response from Restate cluster peers.
 
 Examples:
@@ -2229,12 +2229,12 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="http2-adaptive-window" type="boolean" post={['default=true']}>
+        <ResponseField name="http2-adaptive-window" type="boolean" post={['env: RESTATE_NETWORKING__HTTP2_ADAPTIVE_WINDOW']} default="true">
             HTTP/2 Adaptive Window: 
 
         </ResponseField>
 
-        <ResponseField name="http2-keep-alive-interval" type="string" post={['default="1s"','minLength: 1']}>
+        <ResponseField name="http2-keep-alive-interval" type="string" post={['minLength: 1','env: RESTATE_NETWORKING__HTTP2_KEEP_ALIVE_INTERVAL']} default="1s">
             HTTP/2 Keep Alive Interval: Non-zero duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -2242,7 +2242,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="http2-keep-alive-timeout" type="string" post={['default="3s"','minLength: 1']}>
+        <ResponseField name="http2-keep-alive-timeout" type="string" post={['minLength: 1','env: RESTATE_NETWORKING__HTTP2_KEEP_ALIVE_TIMEOUT']} default="3s">
             HTTP/2 Keep Alive Timeout: Non-zero duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -2250,7 +2250,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="message-size-limit" type="string" post={['minLength: 1']}>
+        <ResponseField name="message-size-limit" type="string" post={['minLength: 1','env: RESTATE_NETWORKING__MESSAGE_SIZE_LIMIT']}>
             Non-zero human-readable bytes
 
         </ResponseField>
@@ -2258,7 +2258,7 @@ Examples:
     </Expandable>
 </ResponseField>
 
-<ResponseField name="no-proxy" type="string | null" post={['default=null']}>
+<ResponseField name="no-proxy" type="string | null" post={['env: RESTATE_NO_PROXY']} default="null">
     No proxy: IP subnets, addresses, and domain names eg `localhost,restate.dev,127.0.0.1,::1,192.168.1.0/24` that should not be proxied by the http_proxy.
 IP addresses must not have ports, and IPv6 addresses must not be wrapped in '[]'.
 Subdomains are also matched. An entry “*” matches all hostnames.
@@ -2266,13 +2266,13 @@ Can be overridden by the `NO_PROXY` environment variable, which supports comma s
 
 </ResponseField>
 
-<ResponseField name="node-name" type="string | null" post={['default=null']}>
+<ResponseField name="node-name" type="string | null" post={['env: RESTATE_NODE_NAME']} default="null">
     Node Name: Unique name for this node in the cluster. The node must not change unless
 it's started with empty local store. It defaults to the node's hostname.
 
 </ResponseField>
 
-<ResponseField name="request-compression-threshold" type="string | null" post={['default="4.0 MiB"']}>
+<ResponseField name="request-compression-threshold" type="string | null" post={['env: RESTATE_REQUEST_COMPRESSION_THRESHOLD']} default="4.0 MiB">
     Request Compression threshold: Request minimum size to enable compression.
 The request size includes the total of the journal replay and its framing using Restate service protocol, without accounting for the json envelope and the base 64 encoding.
 
@@ -2281,7 +2281,7 @@ Default: 4MB (The default AWS Lambda Limit is 6MB, 4MB roughly accounts for +33%
     Human-readable bytes
 </ResponseField>
 
-<ResponseField name="request-identity-private-key-pem-file" type="string | null" post={['default=null']}>
+<ResponseField name="request-identity-private-key-pem-file" type="string | null" post={['env: RESTATE_REQUEST_IDENTITY_PRIVATE_KEY_PEM_FILE']} default="null">
     Request identity private key PEM file: A path to a file, such as \"/var/secrets/key.pem\", which contains exactly one ed25519 private
 key in PEM format. Such a file can be generated with `openssl genpkey -algorithm ed25519`.
 If provided, this key will be used to attach JWTs to requests from this client which
@@ -2292,13 +2292,13 @@ Parsed public keys will be logged at INFO level in the same format that SDKs exp
 
 </ResponseField>
 
-<ResponseField name="rocksdb-bg-threads" type="integer | null" post={['format: uint32','minimum: 1']}>
+<ResponseField name="rocksdb-bg-threads" type="integer | null" post={['format: uint32','minimum: 1','env: RESTATE_ROCKSDB_BG_THREADS']}>
     Rocksdb Background Threads: The number of threads to reserve to Rocksdb background tasks. Defaults to the number of
 cores on the machine.
 
 </ResponseField>
 
-<ResponseField name="rocksdb-block-size" type="string | null" post={[]}>
+<ResponseField name="rocksdb-block-size" type="string | null" post={['env: RESTATE_ROCKSDB_BLOCK_SIZE']}>
     RocksDB block size: Uncompressed block size
 
 Default: 64KiB
@@ -2306,7 +2306,7 @@ Default: 64KiB
     Non-zero human-readable bytes
 </ResponseField>
 
-<ResponseField name="rocksdb-compaction-readahead-size" type="string | null" post={[]}>
+<ResponseField name="rocksdb-compaction-readahead-size" type="string | null" post={['env: RESTATE_ROCKSDB_COMPACTION_READAHEAD_SIZE']}>
     RocksDB compaction readahead size in bytes: If non-zero, we perform bigger reads when doing compaction. If you're
 running RocksDB on spinning disks, you should set this to at least 2MB.
 That way RocksDB's compaction is doing sequential instead of random reads.
@@ -2314,12 +2314,12 @@ That way RocksDB's compaction is doing sequential instead of random reads.
     Non-zero human-readable bytes
 </ResponseField>
 
-<ResponseField name="rocksdb-disable-direct-io-for-flush-and-compactions" type="boolean | null" post={[]}>
+<ResponseField name="rocksdb-disable-direct-io-for-flush-and-compactions" type="boolean | null" post={['env: RESTATE_ROCKSDB_DISABLE_DIRECT_IO_FOR_FLUSH_AND_COMPACTIONS']}>
     Disable Direct IO for flush and compactions: Use O_DIRECT for writes in background flush and compactions.
 
 </ResponseField>
 
-<ResponseField name="rocksdb-disable-direct-io-for-reads" type="boolean | null" post={[]}>
+<ResponseField name="rocksdb-disable-direct-io-for-reads" type="boolean | null" post={['env: RESTATE_ROCKSDB_DISABLE_DIRECT_IO_FOR_READS']}>
     Disable Direct IO for reads: Files will be opened in \"direct I/O\" mode
 which means that data r/w from the disk will not be cached or
 buffered. The hardware buffer of the devices may however still
@@ -2327,33 +2327,33 @@ be used. Memory mapped files are not impacted by these parameters.
 
 </ResponseField>
 
-<ResponseField name="rocksdb-disable-statistics" type="boolean | null" post={[]}>
+<ResponseField name="rocksdb-disable-statistics" type="boolean | null" post={['env: RESTATE_ROCKSDB_DISABLE_STATISTICS']}>
     Disable rocksdb statistics collection
 
 Default: False (statistics enabled)
 
 </ResponseField>
 
-<ResponseField name="rocksdb-disable-wal" type="boolean | null" post={[]}>
+<ResponseField name="rocksdb-disable-wal" type="boolean | null" post={['env: RESTATE_ROCKSDB_DISABLE_WAL']}>
     Disable WAL: The default depends on the different rocksdb use-cases at Restate.
 
 Supports hot-reloading (Partial / Bifrost only)
 
 </ResponseField>
 
-<ResponseField name="rocksdb-high-priority-bg-threads" type="integer" post={['default=2','format: uint32','minimum: 1']}>
+<ResponseField name="rocksdb-high-priority-bg-threads" type="integer" post={['format: uint32','minimum: 1','env: RESTATE_ROCKSDB_HIGH_PRIORITY_BG_THREADS']} default="2">
     Rocksdb High Priority Background Threads: The number of threads to reserve to high priority Rocksdb background tasks.
 
 </ResponseField>
 
-<ResponseField name="rocksdb-log-keep-file-num" type="integer | null" post={['default=null','format: uint']}>
+<ResponseField name="rocksdb-log-keep-file-num" type="integer | null" post={['format: uint','env: RESTATE_ROCKSDB_LOG_KEEP_FILE_NUM']} default="null">
     RocksDB log keep file num: Number of info LOG files to keep
 
 Default: 1
 
 </ResponseField>
 
-<ResponseField name="rocksdb-log-level" type="string | null" post={['default=null']}>
+<ResponseField name="rocksdb-log-level" type="string | null" post={['env: RESTATE_ROCKSDB_LOG_LEVEL']} default="null">
     RocksDB log level: Verbosity of the LOG.
 
 Default: \"error\"
@@ -2361,7 +2361,7 @@ Default: \"error\"
     Verbosity of the LOG.
 </ResponseField>
 
-<ResponseField name="rocksdb-log-max-file-size" type="string | null" post={['default=null']}>
+<ResponseField name="rocksdb-log-max-file-size" type="string | null" post={['env: RESTATE_ROCKSDB_LOG_MAX_FILE_SIZE']} default="null">
     RocksDB log max file size: Max size of info LOG file
 
 Default: 64MB
@@ -2369,12 +2369,12 @@ Default: 64MB
     Non-zero human-readable bytes
 </ResponseField>
 
-<ResponseField name="rocksdb-max-background-jobs" type="integer | null" post={['format: uint32','minimum: 1']}>
+<ResponseField name="rocksdb-max-background-jobs" type="integer | null" post={['format: uint32','minimum: 1','env: RESTATE_ROCKSDB_MAX_BACKGROUND_JOBS']}>
     RocksDB max background jobs (flushes and compactions): Default: the number of CPU cores on this node.
 
 </ResponseField>
 
-<ResponseField name="rocksdb-perf-level"  post={['default="enable-count"']}>
+<ResponseField name="rocksdb-perf-level"  post={['env: RESTATE_ROCKSDB_PERF_LEVEL']} default="enable-count">
     Rocksdb performance statistics level: Defines the level of PerfContext used internally by rocksdb. Default is `enable-count`
 which should be sufficient for most users. Note that higher levels incur a CPU cost and
 might slow down the critical path.
@@ -2388,7 +2388,7 @@ time (neither wall time nor CPU time) for mutexes
     - `"enable-time"` : Enables count and time stats
 </ResponseField>
 
-<ResponseField name="rocksdb-statistics-level" type="oneOf | null" post={[]}>
+<ResponseField name="rocksdb-statistics-level" type="oneOf | null" post={['env: RESTATE_ROCKSDB_STATISTICS_LEVEL']}>
     RocksDB statistics level: StatsLevel can be used to reduce statistics overhead by skipping certain
 types of stats in the stats collection process.
 
@@ -2407,12 +2407,12 @@ If getting time is expensive on the platform to run, it can
 reduce scalability to more threads, especially for writes.
 </ResponseField>
 
-<ResponseField name="rocksdb-total-memory-size" type="string" post={['default="2.0 GiB"','minLength: 1']}>
+<ResponseField name="rocksdb-total-memory-size" type="string" post={['minLength: 1','env: RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE']} default="2.0 GiB">
     Non-zero human-readable bytes
 
 </ResponseField>
 
-<ResponseField name="rocksdb-total-memtables-ratio" type="number" post={['default=0.8500000238418579','format: float']}>
+<ResponseField name="rocksdb-total-memtables-ratio" type="number" post={['format: float','env: RESTATE_ROCKSDB_TOTAL_MEMTABLES_RATIO']} default="0.8500000238418579">
     Rocksdb total memtable size ratio: The memory size used across all memtables (ratio between 0 to 1.0). This
 limits how much memory memtables can eat up from the value in rocksdb-total-memory-limit.
 When set to 0, memtables can take all available memory up to the value specified
@@ -2420,7 +2420,7 @@ in rocksdb-total-memory-limit. This value will be sanitized to 1.0 if outside th
 
 </ResponseField>
 
-<ResponseField name="roles" type="array" post={['default=["http-ingress","admin","worker","log-server","metadata-server"]']}>
+<ResponseField name="roles" type="array" post={[]} default="[&quot;http-ingress&quot;,&quot;admin&quot;,&quot;worker&quot;,&quot;log-server&quot;,&quot;metadata-server&quot;]">
     Defines the roles which this Restate node should run, by default the node
 starts with all roles.
 
@@ -2438,7 +2438,7 @@ starts with all roles.
     </Expandable>
 </ResponseField>
 
-<ResponseField name="shutdown-timeout" type="string" post={['default="1m"','minLength: 1']}>
+<ResponseField name="shutdown-timeout" type="string" post={['minLength: 1','env: RESTATE_SHUTDOWN_TIMEOUT']} default="1m">
     Shutdown grace timeout: This timeout is used when shutting down the various Restate components to drain all the internal queues.
 
 Examples:
@@ -2446,7 +2446,7 @@ Examples:
 
 </ResponseField>
 
-<ResponseField name="storage-high-priority-bg-threads" type="integer | null" post={['format: uint','minimum: 1']}>
+<ResponseField name="storage-high-priority-bg-threads" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_STORAGE_HIGH_PRIORITY_BG_THREADS']}>
     Storage high priority thread pool
 
 This configures the restate-managed storage thread pool for performing
@@ -2455,7 +2455,7 @@ be performed on in-memory caches.
 
 </ResponseField>
 
-<ResponseField name="storage-low-priority-bg-threads" type="integer | null" post={['format: uint','minimum: 1']}>
+<ResponseField name="storage-low-priority-bg-threads" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_STORAGE_LOW_PRIORITY_BG_THREADS']}>
     Storage low priority thread pool
 
 This configures the restate-managed storage thread pool for performing
@@ -2463,13 +2463,13 @@ low-priority or latency-insensitive storage tasks.
 
 </ResponseField>
 
-<ResponseField name="tokio-console-bind-address" type="string" post={[]}>
+<ResponseField name="tokio-console-bind-address" type="string" post={['env: RESTATE_TOKIO_CONSOLE_BIND_ADDRESS']}>
     Address to bind for the tokio-console tracing subscriber. If unset and restate-server is
 built with tokio-console support, it'll listen on `0.0.0.0:6669`.
 
 </ResponseField>
 
-<ResponseField name="tracing-endpoint" type="string | null" post={[]}>
+<ResponseField name="tracing-endpoint" type="string | null" post={['env: RESTATE_TRACING_ENDPOINT']}>
     Tracing Endpoint: This is a shortcut to set both [`Self::tracing_runtime_endpoint`], and [`Self::tracing_services_endpoint`].
 
 Specify the tracing endpoint to send runtime traces to.
@@ -2480,7 +2480,7 @@ To configure the sampling, please refer to the [opentelemetry autoconfigure docs
 
 </ResponseField>
 
-<ResponseField name="tracing-filter" type="string" required post={[]}>
+<ResponseField name="tracing-filter" type="string" required post={['env: RESTATE_TRACING_FILTER']}>
     Tracing Filter: Distributed tracing exporter filter.
 Check the [`RUST_LOG` documentation](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) for more details how to configure it.
 
@@ -2492,7 +2492,7 @@ Use it directly or with `#[serde(with = \"serde_with::As::&lt;serde_with::FromIn
 
 </ResponseField>
 
-<ResponseField name="tracing-json-path" type="string | null" post={[]}>
+<ResponseField name="tracing-json-path" type="string | null" post={['env: RESTATE_TRACING_JSON_PATH']}>
     Distributed Tracing JSON Export Path: If set, an exporter will be configured to write traces to files using the Jaeger JSON format.
 Each trace file will start with the `trace` prefix.
 
@@ -2504,7 +2504,7 @@ To inspect the traces, open the Jaeger UI and use the Upload JSON feature to loa
 
 </ResponseField>
 
-<ResponseField name="tracing-runtime-endpoint" type="string | null" post={[]}>
+<ResponseField name="tracing-runtime-endpoint" type="string | null" post={['env: RESTATE_TRACING_RUNTIME_ENDPOINT']}>
     Runtime Tracing Endpoint: Overrides [`Self::tracing_endpoint`] for runtime traces
 
 Specify the tracing endpoint to send runtime traces to.
@@ -2515,7 +2515,7 @@ To configure the sampling, please refer to the [opentelemetry autoconfigure docs
 
 </ResponseField>
 
-<ResponseField name="tracing-services-endpoint" type="string | null" post={[]}>
+<ResponseField name="tracing-services-endpoint" type="string | null" post={['env: RESTATE_TRACING_SERVICES_ENDPOINT']}>
     Services Tracing Endpoint: Overrides [`Self::tracing_endpoint`] for services traces
 
 Specify the tracing endpoint to send services traces to.
@@ -2526,7 +2526,7 @@ To configure the sampling, please refer to the [opentelemetry autoconfigure docs
 
 </ResponseField>
 
-<ResponseField name="use-random-ports" type="boolean | null" post={[]}>
+<ResponseField name="use-random-ports" type="boolean | null" post={['env: RESTATE_USE_RANDOM_PORTS']}>
     Use random ports instead of the default port
 
 </ResponseField>
@@ -2536,7 +2536,7 @@ To configure the sampling, please refer to the [opentelemetry autoconfigure docs
 
     
     <Expandable title="Properties">
-        <ResponseField name="cleanup-interval" type="string" post={['default="1h"','minLength: 1']}>
+        <ResponseField name="cleanup-interval" type="string" post={['minLength: 1','env: RESTATE_WORKER__CLEANUP_INTERVAL']} default="1h">
             Cleanup interval: In order to clean up completed invocations, that is invocations invoked with an idempotency id, or workflows,
 Restate periodically scans among the completed invocations to check whether they need to be removed or not.
 This interval sets the scan interval of the cleanup procedure. Default: 1 hour.
@@ -2546,7 +2546,7 @@ Examples:
 
         </ResponseField>
 
-        <ResponseField name="durability-mode" type="oneOf | null" post={[]}>
+        <ResponseField name="durability-mode" type="oneOf | null" post={['env: RESTATE_WORKER__DURABILITY_MODE']}>
             Durability mode: Every partition store is backed up by a durable log that is used to recover the state of
 the partition on restart or failover. The durability mode defines the criteria used
 to determine whether a partition is considered fully durable or not at a given point in the
@@ -2606,7 +2606,7 @@ state of durability of the replica-set members.
 DurabilityPoint = SnapshotDurablePoint
         </ResponseField>
 
-        <ResponseField name="internal-queue-length" type="integer" post={['default=1000','format: uint','minimum: 1']}>
+        <ResponseField name="internal-queue-length" type="integer" post={['format: uint','minimum: 1','env: RESTATE_WORKER__INTERNAL_QUEUE_LENGTH']} default="1000">
             Internal queue for partition processor communication: 
 
         </ResponseField>
@@ -2616,7 +2616,7 @@ DurabilityPoint = SnapshotDurablePoint
 
             
             <Expandable title="Properties">
-                <ResponseField name="abort-timeout" type="string" post={['default="10m"','minLength: 1']}>
+                <ResponseField name="abort-timeout" type="string" post={['minLength: 1','env: RESTATE_WORKER__INVOKER__ABORT_TIMEOUT']} default="10m">
                     Human-readable duration: Duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -2624,7 +2624,7 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="action-throttling" type="object | null" post={['default=null']}>
+                <ResponseField name="action-throttling" type="object | null" post={[]} default="null">
                     Action throttling: Configures rate limiting for service actions at the node level.
 This throttling mechanism uses a token bucket algorithm to control the rate
 at which actions can be processed, helping to prevent resource exhaustion
@@ -2638,13 +2638,13 @@ without throttling.
                     Throttling options per invoker.
                     
                     <Expandable title="Properties">
-                        <ResponseField name="capacity" type="integer | null" post={['format: uint32','minimum: 1']}>
+                        <ResponseField name="capacity" type="integer | null" post={['format: uint32','minimum: 1','env: RESTATE_WORKER__INVOKER__ACTION_THROTTLING__CAPACITY']}>
                             Burst capacity: The maximum number of tokens the bucket can hold.
 Default to the rate value if not specified.
 
                         </ResponseField>
 
-                        <ResponseField name="rate" type="string" required post={[]}>
+                        <ResponseField name="rate" type="string" required post={['env: RESTATE_WORKER__INVOKER__ACTION_THROTTLING__RATE']}>
                             Refill rate: The rate at which the tokens are replenished.
 
 Syntax: `&lt;rate&gt;/&lt;unit&gt;` where `&lt;unit&gt;` is `s|sec|second`, `m|min|minute`, or `h|hr|hour`.
@@ -2655,19 +2655,19 @@ unit defaults to per second if not specified.
                     </Expandable>
                 </ResponseField>
 
-                <ResponseField name="concurrent-invocations-limit" type="integer | null" post={['default=1000','format: uint','minimum: 1']}>
+                <ResponseField name="concurrent-invocations-limit" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_WORKER__INVOKER__CONCURRENT_INVOCATIONS_LIMIT']} default="1000">
                     Limit number of concurrent invocations from this node: Number of concurrent invocations that can be processed by the invoker.
 
                 </ResponseField>
 
-                <ResponseField name="in-memory-queue-length-limit" type="integer" post={['default=66049','format: uint','minimum: 1']}>
+                <ResponseField name="in-memory-queue-length-limit" type="integer" post={['format: uint','minimum: 1','env: RESTATE_WORKER__INVOKER__IN_MEMORY_QUEUE_LENGTH_LIMIT']} default="66049">
                     Spill invocations to disk: Defines the threshold after which queues invocations will spill to disk at
 the path defined in `tmp-dir`. In other words, this is the number of invocations
 that can be kept in memory before spilling to disk. This is a per-partition limit.
 
                 </ResponseField>
 
-                <ResponseField name="inactivity-timeout" type="string" post={['default="1m"','minLength: 1']}>
+                <ResponseField name="inactivity-timeout" type="string" post={['minLength: 1','env: RESTATE_WORKER__INVOKER__INACTIVITY_TIMEOUT']} default="1m">
                     Human-readable duration: Duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:
@@ -2675,7 +2675,7 @@ Examples:
 
                 </ResponseField>
 
-                <ResponseField name="invocation-throttling" type="object | null" post={['default=null']}>
+                <ResponseField name="invocation-throttling" type="object | null" post={[]} default="null">
                     Invocation throttling: Configures throttling for service invocations at the node level.
 This throttling mechanism uses a token bucket algorithm to control the rate
 at which invocations can be processed, helping to prevent resource exhaustion
@@ -2689,13 +2689,13 @@ without throttling.
                     Throttling options per invoker.
                     
                     <Expandable title="Properties">
-                        <ResponseField name="capacity" type="integer | null" post={['format: uint32','minimum: 1']}>
+                        <ResponseField name="capacity" type="integer | null" post={['format: uint32','minimum: 1','env: RESTATE_WORKER__INVOKER__INVOCATION_THROTTLING__CAPACITY']}>
                             Burst capacity: The maximum number of tokens the bucket can hold.
 Default to the rate value if not specified.
 
                         </ResponseField>
 
-                        <ResponseField name="rate" type="string" required post={[]}>
+                        <ResponseField name="rate" type="string" required post={['env: RESTATE_WORKER__INVOKER__INVOCATION_THROTTLING__RATE']}>
                             Refill rate: The rate at which the tokens are replenished.
 
 Syntax: `&lt;rate&gt;/&lt;unit&gt;` where `&lt;unit&gt;` is `s|sec|second`, `m|min|minute`, or `h|hr|hour`.
@@ -2706,7 +2706,7 @@ unit defaults to per second if not specified.
                     </Expandable>
                 </ResponseField>
 
-                <ResponseField name="message-size-limit" type="string | null" post={[]}>
+                <ResponseField name="message-size-limit" type="string | null" post={['env: RESTATE_WORKER__INVOKER__MESSAGE_SIZE_LIMIT']}>
                     Message size limit: Maximum size of journal messages that can be received from a service. If a service sends a message
 larger than this limit, the invocation will fail.
 
@@ -2717,12 +2717,12 @@ over the cluster internal network.
                     Non-zero human-readable bytes
                 </ResponseField>
 
-                <ResponseField name="message-size-warning" type="string" post={['default="10.0 MiB"','minLength: 1']}>
+                <ResponseField name="message-size-warning" type="string" post={['minLength: 1','env: RESTATE_WORKER__INVOKER__MESSAGE_SIZE_WARNING']} default="10.0 MiB">
                     Non-zero human-readable bytes
 
                 </ResponseField>
 
-                <ResponseField name="tmp-dir" type="string | null" post={['default=null']}>
+                <ResponseField name="tmp-dir" type="string | null" post={['env: RESTATE_WORKER__INVOKER__TMP_DIR']} default="null">
                     Temporary directory to use for the invoker temporary files.
 If empty, the system temporary directory will be used instead.
 
@@ -2731,13 +2731,13 @@ If empty, the system temporary directory will be used instead.
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="max-command-batch-size" type="integer" post={['default=32','format: uint','minimum: 1']}>
+        <ResponseField name="max-command-batch-size" type="integer" post={['format: uint','minimum: 1','env: RESTATE_WORKER__MAX_COMMAND_BATCH_SIZE']} default="32">
             Maximum command batch size for partition processors: The maximum number of commands a partition processor will apply in a batch. The larger this
 value is, the higher the throughput and latency are.
 
         </ResponseField>
 
-        <ResponseField name="num-timers-in-memory-limit" type="integer | null" post={['default=null','format: uint','minimum: 1']}>
+        <ResponseField name="num-timers-in-memory-limit" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_WORKER__NUM_TIMERS_IN_MEMORY_LIMIT']} default="null">
             Num timers in memory limit: The number of timers in memory limit is used to bound the amount of timers loaded in memory. If this limit is set, when exceeding it, the timers farther in the future will be spilled to disk.
 
         </ResponseField>
@@ -2758,7 +2758,7 @@ retrying every 2 seconds.
                     <Expandable title="Option 1: None">
                     No retry strategy.
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_WORKER__SHUFFLE__CONNECTION_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -2766,7 +2766,7 @@ retrying every 2 seconds.
                     <Expandable title="Option 2: Fixed delay">
                     Retry with a fixed delay strategy.
 
-                        <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                        <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_WORKER__SHUFFLE__CONNECTION_RETRY_POLICY__INTERVAL']}>
                             Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2776,12 +2776,12 @@ Examples:
 
                         </ResponseField>
 
-                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_WORKER__SHUFFLE__CONNECTION_RETRY_POLICY__MAX_ATTEMPTS']}>
                             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                         </ResponseField>
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_WORKER__SHUFFLE__CONNECTION_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -2789,12 +2789,12 @@ Examples:
                     <Expandable title="Option 3: Exponential">
                     Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                        <ResponseField name="factor" type="number" required post={['format: float']}>
+                        <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_WORKER__SHUFFLE__CONNECTION_RETRY_POLICY__FACTOR']}>
                             Factor: The factor to use to compute the next retry attempt.
 
                         </ResponseField>
 
-                        <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                        <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_WORKER__SHUFFLE__CONNECTION_RETRY_POLICY__INITIAL_INTERVAL']}>
                             Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2804,12 +2804,12 @@ Examples:
 
                         </ResponseField>
 
-                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_WORKER__SHUFFLE__CONNECTION_RETRY_POLICY__MAX_ATTEMPTS']}>
                             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                         </ResponseField>
 
-                        <ResponseField name="max-interval" type="string | null" post={[]}>
+                        <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_WORKER__SHUFFLE__CONNECTION_RETRY_POLICY__MAX_INTERVAL']}>
                             Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2820,13 +2820,13 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                         </ResponseField>
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_WORKER__SHUFFLE__CONNECTION_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
                 </ResponseField>
 
-                <ResponseField name="inflight-memory-budget" type="string" required post={['minLength: 1']}>
+                <ResponseField name="inflight-memory-budget" type="string" required post={['minLength: 1','env: RESTATE_WORKER__SHUFFLE__INFLIGHT_MEMORY_BUDGET']}>
                     Inflight Memory Budget: Maximum total size of in-flight ingestion requests in bytes.
 Tune this to your workload so there are enough unpersisted
 requests for efficient batching without exhausting memory.
@@ -2835,7 +2835,7 @@ Defaults to 1 MiB.
 
                 </ResponseField>
 
-                <ResponseField name="request-batch-size" type="string" required post={['minLength: 1']}>
+                <ResponseField name="request-batch-size" type="string" required post={['minLength: 1','env: RESTATE_WORKER__SHUFFLE__REQUEST_BATCH_SIZE']}>
                     Request Batch Size: Maximum size of a single ingestion request batch.
 Tune to keep enough requests per batch for
 throughput; overly large batches can increase tail latency.
@@ -2853,25 +2853,25 @@ worker nodes.
 
             
             <Expandable title="Properties">
-                <ResponseField name="aws-access-key-id" type="string | null" post={[]}>
+                <ResponseField name="aws-access-key-id" type="string | null" post={['env: RESTATE_WORKER__SNAPSHOTS__AWS_ACCESS_KEY_ID']}>
                     AWS access key: Username for Minio, or consult the service documentation for other S3-compatible stores.
 
                 </ResponseField>
 
-                <ResponseField name="aws-allow-http" type="boolean | null" post={[]}>
+                <ResponseField name="aws-allow-http" type="boolean | null" post={['env: RESTATE_WORKER__SNAPSHOTS__AWS_ALLOW_HTTP']}>
                     Allow insecure HTTP: Allow plain HTTP to be used with the object store endpoint. Required when the endpoint URL
 that isn't using HTTPS.
 
                 </ResponseField>
 
-                <ResponseField name="aws-endpoint-url" type="string | null" post={[]}>
+                <ResponseField name="aws-endpoint-url" type="string | null" post={['env: RESTATE_WORKER__SNAPSHOTS__AWS_ENDPOINT_URL']}>
                     Object store API endpoint URL override: When you use Amazon S3, this is typically inferred from the region and there is no need to
 set it. With other object stores, you will have to provide an appropriate HTTP(S) endpoint.
 If *not* using HTTPS, also set `aws-allow-http` to `true`.
 
                 </ResponseField>
 
-                <ResponseField name="aws-profile" type="string | null" post={[]}>
+                <ResponseField name="aws-profile" type="string | null" post={['env: RESTATE_WORKER__SNAPSHOTS__AWS_PROFILE']}>
                     AWS profile: The AWS configuration profile to use for S3 object store destinations. If you use
 named profiles in your AWS configuration, you can replace all the other settings with
 a single profile reference. See the [AWS documentation on profiles]
@@ -2879,7 +2879,7 @@ a single profile reference. See the [AWS documentation on profiles]
 
                 </ResponseField>
 
-                <ResponseField name="aws-region" type="string | null" post={[]}>
+                <ResponseField name="aws-region" type="string | null" post={['env: RESTATE_WORKER__SNAPSHOTS__AWS_REGION']}>
                     AWS region to use with S3 object store destinations. This may be inferred from the
 environment, for example the current region when running in EC2. Because of the
 request signing algorithm this must have a value. For Minio, you can generally
@@ -2887,17 +2887,17 @@ set this to any string, such as `us-east-1`.
 
                 </ResponseField>
 
-                <ResponseField name="aws-secret-access-key" type="string | null" post={[]}>
+                <ResponseField name="aws-secret-access-key" type="string | null" post={['env: RESTATE_WORKER__SNAPSHOTS__AWS_SECRET_ACCESS_KEY']}>
                     AWS secret key: Password for Minio, or consult the service documentation for other S3-compatible stores.
 
                 </ResponseField>
 
-                <ResponseField name="aws-session-token" type="string | null" post={[]}>
+                <ResponseField name="aws-session-token" type="string | null" post={['env: RESTATE_WORKER__SNAPSHOTS__AWS_SESSION_TOKEN']}>
                     AWS session token: This is only needed with short-term STS session credentials.
 
                 </ResponseField>
 
-                <ResponseField name="destination" type="string | null" post={['default=null']}>
+                <ResponseField name="destination" type="string | null" post={['env: RESTATE_WORKER__SNAPSHOTS__DESTINATION']} default="null">
                     Snapshot destination URL: Base URL for cluster snapshots. Currently only supports the `s3://` protocol scheme.
 S3-compatible object stores must support ETag-based conditional writes.
 
@@ -2905,7 +2905,7 @@ Default: `None`
 
                 </ResponseField>
 
-                <ResponseField name="enable-cleanup" type="boolean" post={['default=true']}>
+                <ResponseField name="enable-cleanup" type="boolean" post={['env: RESTATE_WORKER__SNAPSHOTS__ENABLE_CLEANUP']} default="true">
                 </ResponseField>
 
                 <ResponseField name="object-store-retry-policy"  post={[]}>
@@ -2916,7 +2916,7 @@ Default: `None`
                     <Expandable title="Option 1: None">
                     No retry strategy.
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_WORKER__SNAPSHOTS__OBJECT_STORE_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -2924,7 +2924,7 @@ Default: `None`
                     <Expandable title="Option 2: Fixed delay">
                     Retry with a fixed delay strategy.
 
-                        <ResponseField name="interval" type="string" required post={['minLength: 1']}>
+                        <ResponseField name="interval" type="string" required post={['minLength: 1','env: RESTATE_WORKER__SNAPSHOTS__OBJECT_STORE_RETRY_POLICY__INTERVAL']}>
                             Interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2934,12 +2934,12 @@ Examples:
 
                         </ResponseField>
 
-                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_WORKER__SNAPSHOTS__OBJECT_STORE_RETRY_POLICY__MAX_ATTEMPTS']}>
                             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                         </ResponseField>
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_WORKER__SNAPSHOTS__OBJECT_STORE_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
@@ -2947,12 +2947,12 @@ Examples:
                     <Expandable title="Option 3: Exponential">
                     Retry with an exponential strategy. The next retry is computed as `min(last_retry_interval * factor, max_interval)`.
 
-                        <ResponseField name="factor" type="number" required post={['format: float']}>
+                        <ResponseField name="factor" type="number" required post={['format: float','env: RESTATE_WORKER__SNAPSHOTS__OBJECT_STORE_RETRY_POLICY__FACTOR']}>
                             Factor: The factor to use to compute the next retry attempt.
 
                         </ResponseField>
 
-                        <ResponseField name="initial-interval" type="string" required post={['minLength: 1']}>
+                        <ResponseField name="initial-interval" type="string" required post={['minLength: 1','env: RESTATE_WORKER__SNAPSHOTS__OBJECT_STORE_RETRY_POLICY__INITIAL_INTERVAL']}>
                             Initial Interval: Initial interval for the first retry attempt.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2962,12 +2962,12 @@ Examples:
 
                         </ResponseField>
 
-                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1']}>
+                        <ResponseField name="max-attempts" type="integer | null" post={['format: uint','minimum: 1','env: RESTATE_WORKER__SNAPSHOTS__OBJECT_STORE_RETRY_POLICY__MAX_ATTEMPTS']}>
                             Max attempts: Number of maximum attempts before giving up. Infinite retries if unset.
 
                         </ResponseField>
 
-                        <ResponseField name="max-interval" type="string | null" post={[]}>
+                        <ResponseField name="max-interval" type="string | null" post={['env: RESTATE_WORKER__SNAPSHOTS__OBJECT_STORE_RETRY_POLICY__MAX_INTERVAL']}>
                             Max interval: Maximum interval between retries.
 
 Can be configured using the [`jiff::fmt::friendly`](https://docs.rs/jiff/latest/jiff/fmt/friendly/index.html) format or ISO8601, for example `5 hours`.
@@ -2978,13 +2978,13 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                         </ResponseField>
 
-                        <ResponseField name="type" type="string" required post={[]}>
+                        <ResponseField name="type" type="string" required post={['env: RESTATE_WORKER__SNAPSHOTS__OBJECT_STORE_RETRY_POLICY__TYPE']}>
                         </ResponseField>
 
                     </Expandable>
                 </ResponseField>
 
-                <ResponseField name="snapshot-interval" type="string | null" post={[]}>
+                <ResponseField name="snapshot-interval" type="string | null" post={['env: RESTATE_WORKER__SNAPSHOTS__SNAPSHOT_INTERVAL']}>
                     Automatic snapshot time interval: A time interval at which partition snapshots will be created. If
 `snapshot-interval-num-records` is also set, it will be treated as an additional requirement
 before a snapshot is taken. Use both time-based and record-based intervals to reduce the
@@ -3003,7 +3003,7 @@ Examples:
 "10 hours" or "5 days" or "5d" or "1h 4m" or "P40D" or "0"
                 </ResponseField>
 
-                <ResponseField name="snapshot-interval-num-records" type="integer | null" post={['default=null','format: uint64','minimum: 1']}>
+                <ResponseField name="snapshot-interval-num-records" type="integer | null" post={['format: uint64','minimum: 1','env: RESTATE_WORKER__SNAPSHOTS__SNAPSHOT_INTERVAL_NUM_RECORDS']} default="null">
                     Automatic snapshot minimum records: Number of log records that trigger a snapshot to be created.
 
 As snapshots are created asynchronously, the actual number of new records that will trigger
@@ -3024,7 +3024,7 @@ Default: `None` - automatic snapshots are disabled
 
             
             <Expandable title="Properties">
-                <ResponseField name="rocksdb-block-size" type="string | null" post={[]}>
+                <ResponseField name="rocksdb-block-size" type="string | null" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_BLOCK_SIZE']}>
                     RocksDB block size: Uncompressed block size
 
 Default: 64KiB
@@ -3032,7 +3032,7 @@ Default: 64KiB
                     Non-zero human-readable bytes
                 </ResponseField>
 
-                <ResponseField name="rocksdb-compaction-readahead-size" type="string | null" post={[]}>
+                <ResponseField name="rocksdb-compaction-readahead-size" type="string | null" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_COMPACTION_READAHEAD_SIZE']}>
                     RocksDB compaction readahead size in bytes: If non-zero, we perform bigger reads when doing compaction. If you're
 running RocksDB on spinning disks, you should set this to at least 2MB.
 That way RocksDB's compaction is doing sequential instead of random reads.
@@ -3040,7 +3040,7 @@ That way RocksDB's compaction is doing sequential instead of random reads.
                     Non-zero human-readable bytes
                 </ResponseField>
 
-                <ResponseField name="rocksdb-disable-compact-on-deletion" type="boolean" post={[]}>
+                <ResponseField name="rocksdb-disable-compact-on-deletion" type="boolean" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_DISABLE_COMPACT_ON_DELETION']}>
                     Disable compact-on-deletion collector: When set to `true`, disables RocksDB's CompactOnDeletionCollector for partition stores.
 The collector automatically triggers compaction when SST files accumulate a high density
 of tombstones (deletion markers), helping reclaim disk space after bulk deletions.
@@ -3053,12 +3053,12 @@ the collector causing performance issues.
 
                 </ResponseField>
 
-                <ResponseField name="rocksdb-disable-direct-io-for-flush-and-compactions" type="boolean | null" post={[]}>
+                <ResponseField name="rocksdb-disable-direct-io-for-flush-and-compactions" type="boolean | null" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_DISABLE_DIRECT_IO_FOR_FLUSH_AND_COMPACTIONS']}>
                     Disable Direct IO for flush and compactions: Use O_DIRECT for writes in background flush and compactions.
 
                 </ResponseField>
 
-                <ResponseField name="rocksdb-disable-direct-io-for-reads" type="boolean | null" post={[]}>
+                <ResponseField name="rocksdb-disable-direct-io-for-reads" type="boolean | null" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_DISABLE_DIRECT_IO_FOR_READS']}>
                     Disable Direct IO for reads: Files will be opened in \"direct I/O\" mode
 which means that data r/w from the disk will not be cached or
 buffered. The hardware buffer of the devices may however still
@@ -3066,28 +3066,28 @@ be used. Memory mapped files are not impacted by these parameters.
 
                 </ResponseField>
 
-                <ResponseField name="rocksdb-disable-statistics" type="boolean | null" post={[]}>
+                <ResponseField name="rocksdb-disable-statistics" type="boolean | null" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_DISABLE_STATISTICS']}>
                     Disable rocksdb statistics collection
 
 Default: False (statistics enabled)
 
                 </ResponseField>
 
-                <ResponseField name="rocksdb-disable-wal" type="boolean | null" post={[]}>
+                <ResponseField name="rocksdb-disable-wal" type="boolean | null" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_DISABLE_WAL']}>
                     Disable WAL: The default depends on the different rocksdb use-cases at Restate.
 
 Supports hot-reloading (Partial / Bifrost only)
 
                 </ResponseField>
 
-                <ResponseField name="rocksdb-log-keep-file-num" type="integer | null" post={['default=null','format: uint']}>
+                <ResponseField name="rocksdb-log-keep-file-num" type="integer | null" post={['format: uint','env: RESTATE_WORKER__STORAGE__ROCKSDB_LOG_KEEP_FILE_NUM']} default="null">
                     RocksDB log keep file num: Number of info LOG files to keep
 
 Default: 1
 
                 </ResponseField>
 
-                <ResponseField name="rocksdb-log-level" type="string | null" post={['default=null']}>
+                <ResponseField name="rocksdb-log-level" type="string | null" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_LOG_LEVEL']} default="null">
                     RocksDB log level: Verbosity of the LOG.
 
 Default: \"error\"
@@ -3095,7 +3095,7 @@ Default: \"error\"
                     Verbosity of the LOG.
                 </ResponseField>
 
-                <ResponseField name="rocksdb-log-max-file-size" type="string | null" post={['default=null']}>
+                <ResponseField name="rocksdb-log-max-file-size" type="string | null" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_LOG_MAX_FILE_SIZE']} default="null">
                     RocksDB log max file size: Max size of info LOG file
 
 Default: 64MB
@@ -3103,12 +3103,12 @@ Default: 64MB
                     Non-zero human-readable bytes
                 </ResponseField>
 
-                <ResponseField name="rocksdb-max-background-jobs" type="integer | null" post={['format: uint32','minimum: 1']}>
+                <ResponseField name="rocksdb-max-background-jobs" type="integer | null" post={['format: uint32','minimum: 1','env: RESTATE_WORKER__STORAGE__ROCKSDB_MAX_BACKGROUND_JOBS']}>
                     RocksDB max background jobs (flushes and compactions): Default: the number of CPU cores on this node.
 
                 </ResponseField>
 
-                <ResponseField name="rocksdb-memory-budget" type="string | null" post={[]}>
+                <ResponseField name="rocksdb-memory-budget" type="string | null" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_MEMORY_BUDGET']}>
                     The memory budget for rocksdb memtables in bytes
 
 The total is divided evenly across partitions. The server will rebalance the memory budget
@@ -3119,7 +3119,7 @@ If this value is set, it overrides the ratio defined in `rocksdb-memory-ratio`.
                     Non-zero human-readable bytes
                 </ResponseField>
 
-                <ResponseField name="rocksdb-memory-ratio" type="number" post={['default=0.49000000953674316','format: float']}>
+                <ResponseField name="rocksdb-memory-ratio" type="number" post={['format: float','env: RESTATE_WORKER__STORAGE__ROCKSDB_MEMORY_RATIO']} default="0.49000000953674316">
                     The memory budget for rocksdb memtables as ratio
 
 This defines the total memory for rocksdb as a ratio of all memory available to memtables
@@ -3128,7 +3128,7 @@ partitions.
 
                 </ResponseField>
 
-                <ResponseField name="rocksdb-statistics-level" type="oneOf | null" post={[]}>
+                <ResponseField name="rocksdb-statistics-level" type="oneOf | null" post={['env: RESTATE_WORKER__STORAGE__ROCKSDB_STATISTICS_LEVEL']}>
                     RocksDB statistics level: StatsLevel can be used to reduce statistics overhead by skipping certain
 types of stats in the stats collection process.
 
@@ -3150,7 +3150,7 @@ reduce scalability to more threads, especially for writes.
             </Expandable>
         </ResponseField>
 
-        <ResponseField name="trim-delay-interval" type="string" post={['minLength: 1']}>
+        <ResponseField name="trim-delay-interval" type="string" post={['minLength: 1','env: RESTATE_WORKER__TRIM_DELAY_INTERVAL']}>
             Human-readable duration: Duration string in either jiff human friendly or ISO8601 format. Check https://docs.rs/jiff/latest/jiff/struct.Span.html#parsing-and-printing for more details.
 
 Examples:

--- a/scripts/generate-restate-config-viewer.js
+++ b/scripts/generate-restate-config-viewer.js
@@ -86,23 +86,49 @@ function getTypeFromSchema(propSchema) {
     return { type: 'unknown', optional: false };
 }
 
-function getDefaultValueString(propSchema, type) {
-    let value = propSchema.default;
+// Extracts the default value as a display string, or null when the field has
+// no renderable default (unset, or a non-array object default we don't show).
+function getDefaultValue(propSchema, type) {
+    const value = propSchema.default;
     if (value === undefined) return null;
-    else if (value === null) return `default=null`;
-    else if (typeof value === 'string') return `default="${value}"`;
+    else if (value === null) return "null";
+    else if (typeof value === 'string') return value;
     // needs to be checked before 'object' because typeof array is 'object'
-    else if (type === 'array') return `default=${JSON.stringify(value)}`
-    else if (typeof value === 'object') return null
-    else return `default=${String(value)}`;
+    else if (type === 'array') return JSON.stringify(value);
+    else if (typeof value === 'object') return null;
+    else return String(value);
 }
 
-function generatePostAttr(propSchema, type) {
+// Builds the `default="..."` attribute (with a leading space) for a field, or
+// an empty string when there is no renderable default. Inner double quotes are
+// escaped as HTML entities so they don't terminate the JSX attribute.
+function getDefaultAttr(propSchema, type) {
+    const value = getDefaultValue(propSchema, type);
+    return value === null ? "" : ` default="${value.replace(/"/g, '&quot;')}"`;
+}
+
+// Determines whether a field is a settable leaf value (as opposed to a
+// grouping object/array or a oneOf/anyOf container whose variants are objects).
+// Only leaves map to a single environment variable.
+function isLeafField(propSchema, type) {
+    if (type === 'object' || type === 'array') return false;
+    if (type === 'oneOf') return !(propSchema.oneOf || []).some(v => v.properties);
+    if (type === 'anyOf') return !(propSchema.anyOf || []).some(v => v.properties);
+    return true;
+}
+
+// Builds the environment variable name for a config option from its path.
+// Restate uses the `RESTATE_` prefix, `__` between nesting levels, and the
+// snake-cased (upper) field name.
+// TODO: Check if there's a proper way for setting array indicies in env vars
+function buildEnvVar(path) {
+    if (!path || path.length === 0) return null;
+    if (path.includes('[]')) return null;
+    return 'RESTATE_' + path.map(s => s.replace(/-/g, '_').toUpperCase()).join('__');
+}
+
+function generatePostAttr(propSchema, envVar) {
     let postTags = []
-    const defaultValue = getDefaultValueString(propSchema, type)
-    if (defaultValue) {
-        postTags.push(`\'${defaultValue}\'`);
-    }
     if (propSchema.format) {
         postTags.push(`\'format: ${propSchema.format}\'`);
     }
@@ -120,6 +146,9 @@ function generatePostAttr(propSchema, type) {
     }
     if (propSchema.maxLength) {
         postTags.push(`\'maxLength: ${propSchema.maxLength}\'`);
+    }
+    if (envVar) {
+        postTags.push(`\'env: ${envVar}\'`);
     }
 
     return ` post={[${postTags.join(",")}]}`;
@@ -146,26 +175,29 @@ function parseVariantName(variant, index) {
     }
 }
 
-function generateResponseFieldsFromProperties(properties, requiredProps = [], level = 0) {
+function generateResponseFieldsFromProperties(properties, requiredProps = [], level = 0, path = []) {
     let generatedOutput = '';
     Object.entries(properties).forEach(([subPropName, subPropSchema]) => {
         generatedOutput += generateResponseField(
             subPropName,
             subPropSchema,
             requiredProps.includes(subPropName),
-            level + 2
+            level + 2,
+            [...path, subPropName]
         );
     });
     return generatedOutput
 }
 
-function generateResponseField(propName, propSchema, isRequired = false, level = 0) {
+function generateResponseField(propName, propSchema, isRequired = false, level = 0, path = []) {
     const indent = '    '.repeat(level);
     const { type, optional } = getTypeFromSchema(propSchema);
     const required = isRequired && !optional ? ' required' : '';
     let description = formatDescription(propSchema.description, propSchema.title, propSchema.examples);
 
-    let postAttr = generatePostAttr(propSchema, type);
+    const envVar = isLeafField(propSchema, type) ? buildEnvVar(path) : null;
+    let postAttr = generatePostAttr(propSchema, envVar);
+    const defaultAttr = getDefaultAttr(propSchema, type);
 
     // Special case: if type is string and enum has a single value, suggest setting that value (for example for type: "exponential-delay")
     if (propSchema.default === undefined && type === 'string' && Array.isArray(propSchema.enum) && propSchema.enum.length === 1) {
@@ -173,7 +205,7 @@ function generateResponseField(propName, propSchema, isRequired = false, level =
         description += `\n\nSet \`${propName}: "${value}"\``;
     }
 
-    let output = `${indent}<ResponseField name="${propName}" type="${type}"${required}${postAttr}>\n`;
+    let output = `${indent}<ResponseField name="${propName}" type="${type}"${required}${postAttr}${defaultAttr}>\n`;
     if (description) {
         output += `${indent}    ${description}\n\n`;
     }
@@ -189,23 +221,23 @@ function generateResponseField(propName, propSchema, isRequired = false, level =
             variants.forEach((variant, index) => {
                 const variantName = parseVariantName(variant, index);
                 output += `${indent}<Expandable title="${variantName}">\n`;
-                output += generateResponseFieldsFromProperties(variant.properties, propSchema.required, level);
-                output += generateResponseFieldsFromProperties(propSchema.properties, propSchema.required, level);
+                output += generateResponseFieldsFromProperties(variant.properties, propSchema.required, level, path);
+                output += generateResponseFieldsFromProperties(propSchema.properties, propSchema.required, level, path);
                 output += `${indent}    </Expandable>\n`;
             });
 
         } else {
             output += `${indent}    <Expandable title="Properties">\n`;
-            output += generateResponseFieldsFromProperties( propSchema.properties, propSchema.required, level);
+            output += generateResponseFieldsFromProperties( propSchema.properties, propSchema.required, level, path);
             output += `${indent}    </Expandable>\n`;
         }
     }
-    
+
     // Handle array items
     if (type === 'array' && propSchema.items) {
         output += `${indent}    \n`;
         output += `${indent}    <Expandable title="Array Items">\n`;
-        output += generateResponseField('item', propSchema.items, propSchema.required, level + 2);
+        output += generateResponseField('item', propSchema.items, propSchema.required, level + 2, [...path, '[]']);
         output += `${indent}    </Expandable>\n`;
     }
     
@@ -218,7 +250,7 @@ function generateResponseField(propName, propSchema, isRequired = false, level =
             let optionalVariant = variants.find(variant => variant.type !== "null")
 
             const optionalType = getTypeFromSchema(optionalVariant);
-            output = `${indent}<ResponseField name="${propName}" type="${optionalType.type} | null"${required}${postAttr}>\n`;
+            output = `${indent}<ResponseField name="${propName}" type="${optionalType.type} | null"${required}${postAttr}${defaultAttr}>\n`;
             if (description) {
                 output += `${indent}    ${description}\n\n`;
             }
@@ -228,7 +260,7 @@ function generateResponseField(propName, propSchema, isRequired = false, level =
             if (optionalType.type === 'object' && optionalVariant.properties) {
                 output += `${indent}    \n`;
                 output += `${indent}    <Expandable title="Properties">\n`;
-                output += generateResponseFieldsFromProperties(optionalVariant.properties, optionalVariant.required, level);
+                output += generateResponseFieldsFromProperties(optionalVariant.properties, optionalVariant.required, level, path);
                 output += `${indent}    </Expandable>\n`;
 
             } else if (optionalType.type === 'oneOf') {
@@ -238,7 +270,7 @@ function generateResponseField(propName, propSchema, isRequired = false, level =
                 oneOfVariants.forEach((variant, index) => {
                     let variantName = parseVariantName(variant, index)
                     if ((['object', 'oneOf', 'array'].some(t => variant.type.includes(t))) && variant.properties) {
-                        output += generateResponseFieldsFromProperties(variant.properties, variant.required, level);
+                        output += generateResponseFieldsFromProperties(variant.properties, variant.required, level, path);
                     } else {
                         output += `${indent}    - \`${variantName}\` : ${formatDescription(variant.description)}\n`
                     }
@@ -252,7 +284,7 @@ function generateResponseField(propName, propSchema, isRequired = false, level =
                 if ((['object', 'oneOf', 'array'].some(t => variant.type.includes(t))) && variant.properties) {
                     output += `${indent}    \n`;
                     output += `${indent}    <Expandable title="Properties">\n`;
-                    output += generateResponseFieldsFromProperties(variant.properties, variant.required, level);
+                    output += generateResponseFieldsFromProperties(variant.properties, variant.required, level, path);
                     output += `${indent}    </Expandable>\n`;
                 } else {
                     output += `${indent}    - \`${variantName}\` : ${formatDescription(variant.description)}\n`
@@ -266,7 +298,7 @@ function generateResponseField(propName, propSchema, isRequired = false, level =
     if (type === 'oneOf') {
         const variants = propSchema.oneOf
 
-        output = `${indent}<ResponseField name="${propName}" ${required}${postAttr}>\n`;
+        output = `${indent}<ResponseField name="${propName}" ${required}${postAttr}${defaultAttr}>\n`;
         if (description) {
             output += `${indent}    ${description}\n\n`;
         }
@@ -278,7 +310,7 @@ function generateResponseField(propName, propSchema, isRequired = false, level =
                 output += `${indent}    \n`;
                 output += `${indent}    <Expandable title="${variantName || "Properties"}">\n`;
                 output += `${indent}    ${formatDescription(variant.description, undefined, variant.examples)}\n\n`;
-                output += generateResponseFieldsFromProperties( variant.properties, variant.required, level);
+                output += generateResponseFieldsFromProperties( variant.properties, variant.required, level, path);
                 output += `${indent}    </Expandable>\n`;
             } else {
                 output += `${indent}    - \`${variantName}\` : ${formatDescription(variant.description)}\n`
@@ -299,7 +331,7 @@ function generateRestateConfigViewer(schema) {
         '\n\n';
 
     if (schema.properties) {
-        output += generateResponseFieldsFromProperties(schema.properties, schema.required, -2);
+        output += generateResponseFieldsFromProperties(schema.properties, schema.required, -2, []);
     }
     return output;
 }


### PR DESCRIPTION
## Env vars
The main change in this PR is that it adds a new property for leaf configs called `env` which lists their corresponding env variable. This makes it easy to set the config easily as an env variable without having to construct the env variable manually by traversing the parent objs:

<img width="1734" height="1034" alt="CleanShot 2026-06-12 at 11  58 43@2x" src="https://github.com/user-attachments/assets/8ccfc91b-f688-4f20-852d-2938da87d8be" />

The env vars are constructed by following restate server's env format documented [here](https://docs.restate.dev/server/configuration#environment-variables). This, however, skips setting `oneOfs` and `array` because it's not clear how to represent them as env variables.

## Default value

This is mostly cosmetic but apparently the `ResponseField` that we use supports native `default` property, so I changed to using that along the way instead of setting it as a generic `post` property.

<img width="1842" height="566" alt="CleanShot 2026-06-12 at 12  05 48@2x" src="https://github.com/user-attachments/assets/a7c63387-bce2-4359-b20d-2a35fbd7c837" />


