### PR TITLE
add scope and limit key docs for service-to-service calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Development Commands
+
+**Start development server:**
+```bash
+npm run dev
+```
+This command runs both the code loading watcher and the Mintlify docs server concurrently.
+
+**Manual code block updates:**
+```bash
+node scripts/loadScripts.js
+```
+Updates all code blocks in MDX files with content from snippets directory.
+
+## Architecture Overview
+
+This is a **Mintlify documentation site** for Restate, a platform for building resilient applications. The repository structure follows a docs-as-code approach with dynamic code loading.
+
+### Key Components
+
+**Documentation Structure:**
+- `/docs/` - Main documentation files (MDX format)
+- `/restate-plugin` - Restate Coding Agent plugin for Restate Community
+- `/snippets/` - Code examples in multiple languages (TypeScript, Java, Kotlin, Python, Go, Rust)
+- `docs.json` - Mintlify configuration defining navigation and site structure
+
+**Dynamic Code Loading System:**
+- `loadScripts.js` - Watches for changes and injects code from snippets into MDX files
+- Uses special syntax: `{CODE_LOAD::path/to/file#tag?options}` within code blocks
+- Supports multiple languages with language-specific processing
+- Features: code filtering, comment removal, section extraction, prequel collapsing
+
+**Multi-Language SDK Documentation:**
+The docs cover multiple Restate SDKs:
+- TypeScript (primary with most complete docs)
+- Java/Kotlin
+- Python
+- Go
+- Rust
+
+### Content Organization
+
+**Primary documentation paths:**
+- `get-started/` - Onboarding content
+- `develop/` - SDK-specific development guides
+- `deploy/` - Platform deployment instructions
+- `operate/` - Server management and operations
+- `guides/` - Use case patterns and recipes
+- `references/` - Technical references and API docs
+
+**Code snippets structure:**
+- Organized by language: `/snippets/{language}/`
+- Covers common patterns: services, workflows, state management, error handling
+- Uses tagged sections for precise code extraction
+
+### Development Workflow
+
+1. Edit MDX files in `/docs/` for documentation content. Use `{CODE_LOAD::path/to/file#tag?options}` syntax for code blocks
+2. Update code examples in `/snippets/{language}/` directories
+3. Code is automatically injected into MDX files via the loading system with `node scripts/loadScripts.js`
+
+### Special Features
+
+**CODE_LOAD System:**
+- Extracts specific code sections using `<start_tag>` and `<end_tag>` markers
+- Supports filtering with options like `collapse_prequel` and `remove_comments`
+- Handles both local files and GitHub raw URLs
+- Language-aware processing with different comment symbols and service detection
+
+**Navigation:**
+Configured via `docs.json` with tabbed navigation (Learn, Build, Guides) and nested groupings for different SDK languages.
+
+# Mintlify documentation
+
+This is a Mintlify documentation site for Restate. 
+To learn about Mintlify, visit https://www.mintlify.com/docs/llms.txt
+
+## Working relationship
+- You can push back on ideas-this can lead to better documentation. Cite sources and explain your reasoning when you do so
+- ALWAYS ask for clarification rather than making assumptions
+- NEVER lie, guess, or make up information
+
+## Project context
+- Format: MDX files with YAML frontmatter
+- Config: docs.json for navigation, theme, settings
+- Components: Mintlify components
+
+## Content strategy
+- Document just enough for user success - not too much, not too little
+- Prioritize accuracy and usability of information
+- Make content evergreen when possible
+- Search for existing information before adding new content. Avoid duplication unless it is done for a strategic reason
+- Check existing patterns for consistency
+- Start by making the smallest reasonable changes
+
+## docs.json
+
+- Refer to the [docs.json schema](https://mintlify.com/docs.json) when building the docs.json file and site navigation
+
+## Frontmatter requirements for pages
+- title: Clear, descriptive page title
+- description: Concise summary for SEO/navigation
+
+## Writing standards
+- Second-person voice ("you")
+- Prerequisites at start of procedural content
+- Test all code examples before publishing
+- Match style and formatting of existing pages
+- Include both basic and advanced use cases
+- Language tags on all code blocks
+- Alt text on all images
+- Relative paths for internal links
+- Don't use dashes
+
+## Do not
+- Skip frontmatter on any MDX file
+- Use absolute URLs for internal links
+- Include untested code examples
+- Make assumptions - always ask for clarification

--- a/docs/develop/go/service-communication.mdx
+++ b/docs/develop/go/service-communication.mdx
@@ -134,6 +134,52 @@ restate.
 Restate automatically deduplicates calls made during the same handler execution, so there's no need to provide an idempotency key in that case.
 However, if multiple handlers might call the same service independently, you can use an idempotency key to ensure deduplication across those calls.
 
+## Flow control: scope and limit key
+
+<Note title="Preview feature">
+    Scope and limit key are a preview feature and require restate-server 1.7 with [flow control enabled](/services/flow-control#enabling-flow-control).
+</Note>
+
+[Flow control](/services/flow-control) caps how many invocations run concurrently within a **scope**, with optional hierarchical **limit keys**.
+Route a call into a scope with the `restate.WithScope(...)` client option, and add a `restate.WithLimitKey(...)` request option for a finer, per subgroup limit within that scope:
+
+```go {"CODE_LOAD::go/develop/servicecommunication.go#scope"} 
+// Route a call into a named scope with WithScope (a client option)
+svcResponse, err := restate.Service[string](ctx, "MyService", "MyHandler", restate.WithScope("tenant-123")).
+  Request("Hi")
+if err != nil {
+  return err
+}
+
+// Add a limit key for hierarchical concurrency limits within the scope
+wfResponse, err := restate.Workflow[bool](ctx, "MyWorkflow", "my-workflow-id", "Run", restate.WithScope("tenant-123")).
+  Request("Hi", restate.WithLimitKey("premium/user42"))
+if err != nil {
+  return err
+}
+
+// Scoped Virtual Object calls need
+// RESTATE_EXPERIMENTAL_ENABLE_SCOPED_VIRTUAL_OBJECTS=true on the server
+objResponse, err := restate.Object[string](ctx, "MyObject", "Mary", "MyHandler", restate.WithScope("tenant-123")).
+  Request("Hi")
+if err != nil {
+  return err
+}
+
+// Fire-and-forget sends can be scoped too
+restate.ServiceSend(ctx, "MyService", "MyHandler", restate.WithScope("tenant-123")).Send("Hi")
+```
+
+You can read the scope and limit key an invocation was submitted with from the request:
+
+```go {"CODE_LOAD::go/develop/servicecommunication.go#scope_request"} 
+// The scope and limit key the invocation was submitted with
+scope := ctx.Request().Scope
+limitKey := ctx.Request().LimitKey
+```
+
+See [Flow control](/services/flow-control) for how scopes, limit keys, and the concurrency rule book work.
+
 ## Attach to an invocation
 
 To wait for or get the result of a previously sent message:

--- a/docs/develop/go/service-communication.mdx
+++ b/docs/develop/go/service-communication.mdx
@@ -147,24 +147,15 @@ Route a call into a scope with the `restate.WithScope(...)` client option, and a
 // Route a call into a named scope with WithScope (a client option)
 svcResponse, err := restate.Service[string](ctx, "MyService", "MyHandler", restate.WithScope("tenant-123")).
   Request("Hi")
-if err != nil {
-  return err
-}
 
 // Add a limit key for hierarchical concurrency limits within the scope
 wfResponse, err := restate.Workflow[bool](ctx, "MyWorkflow", "my-workflow-id", "Run", restate.WithScope("tenant-123")).
   Request("Hi", restate.WithLimitKey("premium/user42"))
-if err != nil {
-  return err
-}
 
 // Scoped Virtual Object calls need
 // RESTATE_EXPERIMENTAL_ENABLE_SCOPED_VIRTUAL_OBJECTS=true on the server
 objResponse, err := restate.Object[string](ctx, "MyObject", "Mary", "MyHandler", restate.WithScope("tenant-123")).
   Request("Hi")
-if err != nil {
-  return err
-}
 
 // Fire-and-forget sends can be scoped too
 restate.ServiceSend(ctx, "MyService", "MyHandler", restate.WithScope("tenant-123")).Send("Hi")
@@ -173,6 +164,10 @@ restate.ServiceSend(ctx, "MyService", "MyHandler", restate.WithScope("tenant-123
 You can read the scope and limit key an invocation was submitted with from the request:
 
 ```go {"CODE_LOAD::go/develop/servicecommunication.go#scope_request"} 
+if err != nil {
+  return err
+}
+
 // The scope and limit key the invocation was submitted with
 scope := ctx.Request().Scope
 limitKey := ctx.Request().LimitKey

--- a/docs/develop/java/service-communication.mdx
+++ b/docs/develop/java/service-communication.mdx
@@ -199,6 +199,68 @@ toService<MyService>()
 Restate automatically deduplicates calls made during the same handler execution, so there's no need to provide an idempotency key in that case.
 However, if multiple handlers might call the same service independently, you can use an idempotency key to ensure deduplication across those calls.
 
+## Flow control: scope and limit key
+
+<Note title="Preview feature">
+    Scope and limit key are a preview feature and require restate-server 1.7 with [flow control enabled](/services/flow-control#enabling-flow-control).
+</Note>
+
+[Flow control](/services/flow-control) caps how many invocations run concurrently within a **scope**, with optional hierarchical **limit keys**.
+Route a call into a scope with `Restate.scope(...)` (Java) or `scope(...)` (Kotlin), and add a limit key for a finer, per subgroup limit within that scope:
+
+<CodeGroup>
+```java Java {"CODE_LOAD::java/src/main/java/develop/ServiceCommunication.java#scope"} 
+// Route a call into a named scope
+String svcResponse = Restate.scope("tenant-123").service(MyService.class).myHandler(request);
+
+// Add a limit key for hierarchical concurrency limits within the scope
+String wfResponse =
+    Restate.scope("tenant-123")
+        .workflowHandle(MyWorkflow.class, workflowId)
+        .call(MyWorkflow::run, request, InvocationOptions.limitKey("premium/user42"))
+        .await();
+
+// Scoped Virtual Object calls need
+// RESTATE_EXPERIMENTAL_ENABLE_SCOPED_VIRTUAL_OBJECTS=true on the server
+String objResponse =
+    Restate.scope("tenant-123").virtualObject(MyObject.class, objectKey).myHandler(request);
+```
+```kotlin Kotlin {"CODE_LOAD::kotlin/src/main/kotlin/develop/ServiceCommunication.kt#scope"} 
+// Route a call into a named scope
+val svcResponse = scope("tenant-123").service<MyService>().myHandler(request)
+
+// Add a limit key for hierarchical concurrency limits within the scope
+val wfResponse =
+    scope("tenant-123")
+        .toWorkflow<MyWorkflow>(workflowId)
+        .request { run(request) }
+        .options { limitKey = "premium/user42" }
+        .call()
+        .await()
+
+// Scoped Virtual Object calls need
+// RESTATE_EXPERIMENTAL_ENABLE_SCOPED_VIRTUAL_OBJECTS=true on the server
+val objResponse = scope("tenant-123").virtualObject<MyObject>(objectKey).myHandler(request)
+```
+</CodeGroup>
+
+You can read the scope and limit key an invocation was submitted with from the request:
+
+<CodeGroup>
+```java Java {"CODE_LOAD::java/src/main/java/develop/ServiceCommunication.java#scope_request"} 
+// The scope and limit key the invocation was submitted with
+String scope = Restate.request().scope();
+String limitKey = Restate.request().limitKey();
+```
+```kotlin Kotlin {"CODE_LOAD::kotlin/src/main/kotlin/develop/ServiceCommunication.kt#scope_request"} 
+// The scope and limit key the invocation was submitted with
+val invocationScope = request().scope
+val invocationLimitKey = request().limitKey
+```
+</CodeGroup>
+
+See [Flow control](/services/flow-control) for how scopes, limit keys, and the concurrency rule book work.
+
 ## Attach to an invocation
 To wait for or get the result of a previously sent message:
 

--- a/docs/develop/python/service-communication.mdx
+++ b/docs/develop/python/service-communication.mdx
@@ -148,6 +148,38 @@ await ctx.service_call(
 Restate automatically deduplicates calls made during the same handler execution, so there's no need to provide an idempotency key in that case.
 However, if multiple handlers might call the same service independently, you can use an idempotency key to ensure deduplication across those calls.
 
+## Flow control: scope and limit key
+
+<Note title="Preview feature">
+    Scope and limit key are a preview feature and require restate-server 1.7 with [flow control enabled](/services/flow-control#enabling-flow-control).
+</Note>
+
+[Flow control](/services/flow-control) caps how many invocations run concurrently within a **scope**, with optional hierarchical **limit keys**.
+Route a call into a scope with `ctx.scope(...)`, and add a `limit_key` for a finer, per subgroup limit within that scope:
+
+```python {"CODE_LOAD::python/src/develop/service_communication.py#scope"} 
+# Route a call into a named scope
+response = await ctx.scope("tenant-123").service_call(my_service_handler, arg="Hi")
+
+# Add a limit key for hierarchical concurrency limits within the scope
+response = await ctx.scope("tenant-123").workflow_call(
+    run, key="my_workflow_id", arg="Hi", limit_key="premium/user42"
+)
+
+# Fire-and-forget sends can be scoped too
+ctx.scope("tenant-123").service_send(my_service_handler, arg="Hi")
+```
+
+You can read the scope and limit key an invocation was submitted with from the request:
+
+```python {"CODE_LOAD::python/src/develop/service_communication.py#scope_request"} 
+# The scope and limit key the invocation was submitted with
+scope = ctx.request().scope
+limit_key = ctx.request().limit_key
+```
+
+See [Flow control](/services/flow-control) for how scopes, limit keys, and the concurrency rule book work.
+
 ## Attach to an invocation
 
 To wait for or get the result of a previously sent message:

--- a/docs/develop/ts/service-communication.mdx
+++ b/docs/develop/ts/service-communication.mdx
@@ -172,6 +172,51 @@ ctx.serviceSendClient(myService).myHandler(
 Restate automatically deduplicates calls made during the same handler execution, so there's no need to provide an idempotency key in that case.
 However, if multiple handlers might call the same service independently, you can use an idempotency key to ensure deduplication across those calls.
 
+## Flow control: scope and limit key
+
+<Note title="Preview feature">
+    Scope and limit key are a preview feature and require restate-server 1.7 with [flow control enabled](/services/flow-control#enabling-flow-control).
+</Note>
+
+[Flow control](/services/flow-control) caps how many invocations run concurrently within a **scope**, with optional hierarchical **limit keys**.
+Route a call into a scope with `ctx.scope(...)`, and add a `limitKey` for a finer, per subgroup limit within that scope:
+
+```ts {"CODE_LOAD::ts/src/develop/service_communication.ts#scope"} 
+// Route a call into a named scope
+const svcResponse = await ctx
+  .scope("tenant-123")
+  .serviceClient(myService)
+  .myHandler("Hi");
+
+// Add a limit key for hierarchical concurrency limits within the scope
+const wfResponse = await ctx
+  .scope("tenant-123")
+  .workflowClient(myWorkflow, "wf-id")
+  .run("Hi", restate.rpc.opts({ limitKey: "premium/user42" }));
+
+// Scoped Virtual Object calls need
+// RESTATE_EXPERIMENTAL_ENABLE_SCOPED_VIRTUAL_OBJECTS=true on the server
+const objResponse = await ctx
+  .scope("tenant-123")
+  .objectClient(myObject, "Mary")
+  .myHandler("Hi");
+
+// Fire-and-forget sends can be scoped too
+ctx.scope("tenant-123").serviceSendClient(myService).myHandler("Hi");
+```
+
+You can read the scope and limit key an invocation was submitted with from the request:
+
+```ts {"CODE_LOAD::ts/src/develop/service_communication.ts#scope_request"} 
+// The scope and limit key the invocation was submitted with
+const scope = ctx.request().scope;
+const limitKey = ctx.request().limitKey;
+```
+
+The same scoping is available on the [SDK clients](/services/invocation/clients/typescript-sdk) for calls from outside Restate, via `connect({ url }).scope("tenant-123")`.
+
+See [Flow control](/services/flow-control) for how scopes, limit keys, and the concurrency rule book work.
+
 ## Attach to an invocation
 
 To wait for or get the result of a previously sent message:

--- a/docs/develop/ts/service-communication.mdx
+++ b/docs/develop/ts/service-communication.mdx
@@ -213,8 +213,6 @@ const scope = ctx.request().scope;
 const limitKey = ctx.request().limitKey;
 ```
 
-The same scoping is available on the [SDK clients](/services/invocation/clients/typescript-sdk) for calls from outside Restate, via `connect({ url }).scope("tenant-123")`.
-
 See [Flow control](/services/flow-control) for how scopes, limit keys, and the concurrency rule book work.
 
 ## Attach to an invocation

--- a/docs/services/flow-control.mdx
+++ b/docs/services/flow-control.mdx
@@ -31,7 +31,7 @@ Planned follow-ups include throttling and rate limits, invocation priorities, an
 
 ## Scopes
 
-A **scope** is a namespace for concurrency control.
+A **scope** is a namespace that Restate applies concurrency limits over, and that also namespaces the **identity** of everything inside it.
 Every invocation can carry a scope, and concurrency limits are applied per scope: all invocations sharing the same scope draw from the same concurrency budget.
 
 You choose what a scope represents. For example, you might scope by:
@@ -39,6 +39,11 @@ You choose what a scope represents. For example, you might scope by:
 - A tenant or customer, to give each one a fair share of capacity.
 - A downstream dependency, to bound how many invocations hit it at once.
 - A class of work, such as `checkout` or `ai-agent`, to cap how much of it runs concurrently.
+
+A scope is more than a concurrency bucket. It becomes **part of the identity of every invocation and resource inside it**, so the same thing addressed under two different scopes is isolated:
+
+- **Idempotency is tracked per scope.** The same idempotency key deduplicates only within one scope. Reused under a different scope, it starts a separate invocation.
+- **Virtual Object and Workflow keys are per scope.** A `Cart` object with key `"a"` under scope `bob` is a different instance, with its own state and queue, from `Cart` `"a"` under scope `joe`. (Routing scoped calls to Virtual Objects requires the [extra opt-in](#enabling-flow-control).)
 
 You attach a scope to an invocation by sending it through a [scoped ingress endpoint](#applying-concurrency-limits), and you define limits per scope through the [rule book](#configuring-concurrency-limits).
 
@@ -78,6 +83,8 @@ Flow control is disabled by default. Enable it in your server configuration:
 ```toml restate.toml
 experimental-enable-protocol-v7 = true
 experimental-enable-vqueues = true
+# Only to route scoped calls to Virtual Objects
+experimental-enable-scoped-virtual-objects = true
 ```
 
 Or via the environment variable:
@@ -85,6 +92,8 @@ Or via the environment variable:
 ```shell
 RESTATE_EXPERIMENTAL_ENABLE_PROTOCOL_V7=true
 RESTATE_EXPERIMENTAL_ENABLE_VQUEUES=true
+# Only to route scoped calls to Virtual Objects
+RESTATE_EXPERIMENTAL_ENABLE_SCOPED_VIRTUAL_OBJECTS=true
 ```
 
 <Warning title="Enable only on fresh clusters">
@@ -202,6 +211,16 @@ A limit key always requires a scope: sending one without a `scope/{scopeKey}` se
     Invocations sent through the non-scoped endpoints (`/restate/call/...` and `/restate/send/...`) are not subject to any scope-based limit.
     See [HTTP invocation](/services/invocation/http) for the full set of ingress endpoints.
 </Info>
+
+### From an SDK handler
+
+Service-to-service calls made from a handler can carry a scope and limit key too, so the invocations they trigger count against the same rule book.
+Each SDK exposes a scoped client for this:
+
+- [TypeScript](/develop/ts/service-communication#flow-control-scope-and-limit-key)
+- [Python](/develop/python/service-communication#flow-control-scope-and-limit-key)
+- [Java / Kotlin](/develop/java/service-communication#flow-control-scope-and-limit-key)
+- [Go](/develop/go/service-communication#flow-control-scope-and-limit-key)
 
 ## Example: a multi-tenant inference platform
 

--- a/docs/services/flow-control.mdx
+++ b/docs/services/flow-control.mdx
@@ -32,6 +32,7 @@ Planned follow-ups include throttling and rate limits, invocation priorities, an
 ## Scopes
 
 A **scope** is a namespace that Restate applies concurrency limits over, and that also namespaces the **identity** of everything inside it.
+
 Every invocation can carry a scope, and concurrency limits are applied per scope: all invocations sharing the same scope draw from the same concurrency budget.
 
 You choose what a scope represents. For example, you might scope by:

--- a/docs/services/invocation/clients/go-sdk.mdx
+++ b/docs/services/invocation/clients/go-sdk.mdx
@@ -122,6 +122,36 @@ The call options, with which we set the idempotency key, also let you add other 
     Check out the [service configuration docs](/services/configuration) to tune the retention time.
 </Info>
 
+## Flow control: scope and limit key
+
+<Note title="Preview feature">
+    Scope and limit key are a preview feature and require restate-server 1.7 with [flow control enabled](/services/flow-control#enabling-flow-control).
+</Note>
+
+[Flow control](/services/flow-control) caps how many invocations run concurrently within a **scope**, with optional hierarchical **limit keys**.
+Route a call into a scope with the `restate.WithScope(...)` client option, and add a `restate.WithLimitKey(...)` request option for a finer, per subgroup limit within that scope:
+
+```go {"CODE_LOAD::go/develop/ingressclients.go#scope"} 
+restateClient := restateingress.NewClient("http://localhost:8080")
+
+// Route a call into a named scope with WithScope (a client option)
+svcResponse, err := restateingress.Service[*MyInput, *MyOutput](
+  restateClient, "MyService", "MyHandler", restate.WithScope("tenant-123")).
+  Request(context.Background(), &input)
+
+// Add a limit key for a hierarchical concurrency limit within the scope
+objResponse, err := restateingress.Object[*MyInput, *MyOutput](
+  restateClient, "MyObject", "Mary", "MyHandler", restate.WithScope("tenant-123")).
+  Request(context.Background(), &input, restate.WithLimitKey("premium/user42"))
+
+// Fire-and-forget sends can be scoped too
+_, err = restateingress.ServiceSend[*MyInput](
+  restateClient, "MyService", "MyHandler", restate.WithScope("tenant-123")).
+  Send(context.Background(), &input)
+```
+
+See [Flow control](/services/flow-control) for how scopes, limit keys, and the concurrency rule book work.
+
 ## Retrieve result of invocations and workflows
 
 You can use the client library to retrieve the results of invocations **with an idempotency key** or workflows.

--- a/docs/services/invocation/clients/java-sdk.mdx
+++ b/docs/services/invocation/clients/java-sdk.mdx
@@ -175,6 +175,60 @@ The call options, with which we set the idempotency key, also let you add other 
     Check out the [service configuration docs](/services/configuration) to tune the retention time.
 </Info>
 
+## Flow control: scope and limit key
+
+<Note title="Preview feature">
+    Scope and limit key are a preview feature and require restate-server 1.7 with [flow control enabled](/services/flow-control#enabling-flow-control).
+</Note>
+
+[Flow control](/services/flow-control) caps how many invocations run concurrently within a **scope**, with optional hierarchical **limit keys**.
+Route a call into a scope with `.scope(...)` on the client, and add a limit key via `InvocationOptions.limitKey(...)` (Java) or `.options { limitKey = ... }` (Kotlin) for a finer, per subgroup limit within that scope:
+
+<CodeGroup>
+```java Java {"CODE_LOAD::java/src/main/java/develop/IngressClient.java#scope"} 
+Client restateClient = Client.connect("http://localhost:8080");
+
+// Route a call into a named scope
+String svcResponse =
+    restateClient.scope("tenant-123").service(MyService.class).myHandler("Hi");
+
+// Add a limit key for a hierarchical concurrency limit within the scope
+String objResponse =
+    restateClient
+        .scope("tenant-123")
+        .virtualObjectHandle(MyObject.class, "Mary")
+        .call(MyObject::myHandler, "Hi", InvocationOptions.limitKey("premium/user42"))
+        .response();
+
+// Fire-and-forget sends can be scoped too
+restateClient
+    .scope("tenant-123")
+    .serviceHandle(MyService.class)
+    .send(MyService::myHandler, "Hi");
+```
+```kotlin Kotlin {"CODE_LOAD::kotlin/src/main/kotlin/develop/IngressClient.kt#scope"} 
+val restateClient = Client.connect("http://localhost:8080")
+
+// Route a call into a named scope
+val svcResponse = restateClient.scope("tenant-123").service<MyService>().myHandler("Hi")
+
+// Add a limit key for a hierarchical concurrency limit within the scope
+val objResponse =
+    restateClient
+        .scope("tenant-123")
+        .toVirtualObject<MyObject>("Mary")
+        .request { myHandler("Hi") }
+        .options { limitKey = "premium/user42" }
+        .call()
+        .response()
+
+// Fire-and-forget sends can be scoped too
+restateClient.scope("tenant-123").toService<MyService>().request { myHandler("Hi") }.send()
+```
+</CodeGroup>
+
+See [Flow control](/services/flow-control) for how scopes, limit keys, and the concurrency rule book work.
+
 ## Retrieve result of invocations and workflows
 
 You can use the client library to retrieve the results of invocations **with an idempotency key** or workflows.

--- a/docs/services/invocation/clients/typescript-sdk.mdx
+++ b/docs/services/invocation/clients/typescript-sdk.mdx
@@ -174,6 +174,39 @@ if (peekOutput.ready) {
 }
 ```
 
+## Flow control: scope and limit key
+
+<Note title="Preview feature">
+    Scope and limit key are a preview feature and require restate-server 1.7 with [flow control enabled](/services/flow-control#enabling-flow-control).
+</Note>
+
+[Flow control](/services/flow-control) caps how many invocations run concurrently within a **scope**, with optional hierarchical **limit keys**.
+Route a call into a scope with `.scope(...)` on the client, and add a `limitKey` for a finer, per subgroup limit within that scope:
+
+```ts {"CODE_LOAD::ts/src/develop/clients/ingress.ts#scope"} 
+const restateClient = clients.connect({ url: "http://localhost:8080" });
+
+// Route a call into a named scope
+const greet = await restateClient
+  .scope("tenant-123")
+  .serviceClient<MyService>({ name: "MyService" })
+  .greet(request);
+
+// Add a limit key for a hierarchical concurrency limit within the scope
+const count = await restateClient
+  .scope("tenant-123")
+  .objectClient<MyObject>({ name: "MyObject" }, "Mary")
+  .greet(request, clients.rpc.opts({ limitKey: "premium/user42" }));
+
+// Fire-and-forget sends can be scoped too
+await restateClient
+  .scope("tenant-123")
+  .serviceSendClient<MyService>({ name: "MyService" })
+  .greet(request);
+```
+
+See [Flow control](/services/flow-control) for how scopes, limit keys, and the concurrency rule book work.
+
 ## Advanced: sharing service type definitions
 
 Have a look at the options listed in the [Service Communication docs](/develop/ts/service-communication#advanced%3A-sharing-service-type-definitions). These are also valid for the SDK clients.

--- a/snippets/go/develop/ingressclients.go
+++ b/snippets/go/develop/ingressclients.go
@@ -179,6 +179,35 @@ func (c *IngressClient) workflowAttach() error {
 	return nil
 }
 
+func (c *IngressClient) scopedClient() error {
+	var input MyInput
+	input.Name = "Hi"
+
+	// <start_scope>
+	restateClient := restateingress.NewClient("http://localhost:8080")
+
+	// Route a call into a named scope with WithScope (a client option)
+	svcResponse, err := restateingress.Service[*MyInput, *MyOutput](
+		restateClient, "MyService", "MyHandler", restate.WithScope("tenant-123")).
+		Request(context.Background(), &input)
+
+	// Add a limit key for a hierarchical concurrency limit within the scope
+	objResponse, err := restateingress.Object[*MyInput, *MyOutput](
+		restateClient, "MyObject", "Mary", "MyHandler", restate.WithScope("tenant-123")).
+		Request(context.Background(), &input, restate.WithLimitKey("premium/user42"))
+
+	// Fire-and-forget sends can be scoped too
+	_, err = restateingress.ServiceSend[*MyInput](
+		restateClient, "MyService", "MyHandler", restate.WithScope("tenant-123")).
+		Send(context.Background(), &input)
+	// <end_scope>
+
+	_ = svcResponse
+	_ = objResponse
+	_ = err
+	return nil
+}
+
 // Mock data structures
 type MyInput struct {
 	Name string

--- a/snippets/go/develop/servicecommunication.go
+++ b/snippets/go/develop/servicecommunication.go
@@ -111,6 +111,43 @@ func (Router) Greet3(ctx restate.Context, name string) error {
 	return nil
 }
 
+func (Router) GreetScoped(ctx restate.Context, name string) error {
+	// <start_scope>
+	// Route a call into a named scope with WithScope (a client option)
+	svcResponse, err := restate.Service[string](ctx, "MyService", "MyHandler", restate.WithScope("tenant-123")).
+		Request("Hi")
+
+	// Add a limit key for hierarchical concurrency limits within the scope
+	wfResponse, err := restate.Workflow[bool](ctx, "MyWorkflow", "my-workflow-id", "Run", restate.WithScope("tenant-123")).
+		Request("Hi", restate.WithLimitKey("premium/user42"))
+
+	// Scoped Virtual Object calls need
+	// RESTATE_EXPERIMENTAL_ENABLE_SCOPED_VIRTUAL_OBJECTS=true on the server
+	objResponse, err := restate.Object[string](ctx, "MyObject", "Mary", "MyHandler", restate.WithScope("tenant-123")).
+		Request("Hi")
+
+	// Fire-and-forget sends can be scoped too
+	restate.ServiceSend(ctx, "MyService", "MyHandler", restate.WithScope("tenant-123")).Send("Hi")
+	// <end_scope>
+
+	// <start_scope_request>
+	if err != nil {
+		return err
+	}
+
+	// The scope and limit key the invocation was submitted with
+	scope := ctx.Request().Scope
+	limitKey := ctx.Request().LimitKey
+	// <end_scope_request>
+
+	_ = svcResponse
+	_ = wfResponse
+	_ = objResponse
+	_ = scope
+	_ = limitKey
+	return nil
+}
+
 func (Router) Greet4(ctx restate.Context, name string) error {
 	// <start_cancel>
 	// Execute the request and retrieve the invocation id

--- a/snippets/go/develop/servicecommunication.go
+++ b/snippets/go/develop/servicecommunication.go
@@ -13,32 +13,23 @@ func (Router) Greet(ctx restate.Context, name string) error {
 	// To call a Service:
 	svcResponse, err := restate.Service[string](ctx, "MyService", "MyHandler").
 		Request("Hi")
-	if err != nil {
-		return err
-	}
 
 	// To call a Virtual Object:
 	objResponse, err := restate.Object[string](ctx, "MyObject", "Mary", "MyHandler").
 		Request("Hi")
-	if err != nil {
-		return err
-	}
 
 	// To call a Workflow:
 	// `run` handler — can only be called once per workflow ID
 	wfResponse, err := restate.Workflow[bool](ctx, "MyWorkflow", "my-workflow-id", "Run").
 		Request("Hi")
-	if err != nil {
-		return err
-	}
 	// Other handlers can be called anytime within workflow retention
 	status, err := restate.Workflow[restate.Void](ctx, "MyWorkflow", "my-workflow-id", "GetStatus").
 		Request("Hi again")
+	// <end_request_response>
+
 	if err != nil {
 		return err
 	}
-	// <end_request_response>
-
 	_ = svcResponse
 	_ = objResponse
 	_ = wfResponse
@@ -130,11 +121,11 @@ func (Router) GreetScoped(ctx restate.Context, name string) error {
 	restate.ServiceSend(ctx, "MyService", "MyHandler", restate.WithScope("tenant-123")).Send("Hi")
 	// <end_scope>
 
-	// <start_scope_request>
 	if err != nil {
 		return err
 	}
 
+	// <start_scope_request>
 	// The scope and limit key the invocation was submitted with
 	scope := ctx.Request().Scope
 	limitKey := ctx.Request().LimitKey

--- a/snippets/java/gradle/libs.versions.toml
+++ b/snippets/java/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-restate = '2.9.0'
+restate = '2.9.1'
 opentelemetry = '1.58.0'
 jackson = '2.18.1'
 junit = '5.11.3'

--- a/snippets/java/src/main/java/develop/IngressClient.java
+++ b/snippets/java/src/main/java/develop/IngressClient.java
@@ -153,8 +153,7 @@ public class IngressClient {
     Client restateClient = Client.connect("http://localhost:8080");
 
     // Route a call into a named scope
-    String svcResponse =
-        restateClient.scope("tenant-123").service(MyService.class).myHandler("Hi");
+    String svcResponse = restateClient.scope("tenant-123").service(MyService.class).myHandler("Hi");
 
     // Add a limit key for a hierarchical concurrency limit within the scope
     String objResponse =

--- a/snippets/java/src/main/java/develop/IngressClient.java
+++ b/snippets/java/src/main/java/develop/IngressClient.java
@@ -147,4 +147,28 @@ public class IngressClient {
     // use it to attach or peek (see above)
     // <end_workflow_attach>
   }
+
+  public void scopedClient() {
+    // <start_scope>
+    Client restateClient = Client.connect("http://localhost:8080");
+
+    // Route a call into a named scope
+    String svcResponse =
+        restateClient.scope("tenant-123").service(MyService.class).myHandler("Hi");
+
+    // Add a limit key for a hierarchical concurrency limit within the scope
+    String objResponse =
+        restateClient
+            .scope("tenant-123")
+            .virtualObjectHandle(MyObject.class, "Mary")
+            .call(MyObject::myHandler, "Hi", InvocationOptions.limitKey("premium/user42"))
+            .response();
+
+    // Fire-and-forget sends can be scoped too
+    restateClient
+        .scope("tenant-123")
+        .serviceHandle(MyService.class)
+        .send(MyService::myHandler, "Hi");
+    // <end_scope>
+  }
 }

--- a/snippets/java/src/main/java/develop/ServiceCommunication.java
+++ b/snippets/java/src/main/java/develop/ServiceCommunication.java
@@ -117,6 +117,35 @@ public class ServiceCommunication {
     // <end_delayed>
   }
 
+  private void scope() {
+    String request = "";
+    String workflowId = "";
+    String objectKey = "";
+
+    // <start_scope>
+    // Route a call into a named scope
+    String svcResponse = Restate.scope("tenant-123").service(MyService.class).myHandler(request);
+
+    // Add a limit key for hierarchical concurrency limits within the scope
+    String wfResponse =
+        Restate.scope("tenant-123")
+            .workflowHandle(MyWorkflow.class, workflowId)
+            .call(MyWorkflow::run, request, InvocationOptions.limitKey("premium/user42"))
+            .await();
+
+    // Scoped Virtual Object calls need
+    // RESTATE_EXPERIMENTAL_ENABLE_SCOPED_VIRTUAL_OBJECTS=true on the server
+    String objResponse =
+        Restate.scope("tenant-123").virtualObject(MyObject.class, objectKey).myHandler(request);
+    // <end_scope>
+
+    // <start_scope_request>
+    // The scope and limit key the invocation was submitted with
+    String scope = Restate.request().scope();
+    String limitKey = Restate.request().limitKey();
+    // <end_scope_request>
+  }
+
   private void orderingGuarantees() {
     String objectKey = "";
     // <start_ordering>

--- a/snippets/kotlin/src/main/kotlin/develop/IngressClient.kt
+++ b/snippets/kotlin/src/main/kotlin/develop/IngressClient.kt
@@ -136,4 +136,26 @@ class IngressClient {
     // use it to attach or peek (see above)
     // <end_workflow_attach>
   }
+
+  suspend fun scopedClient() {
+    // <start_scope>
+    val restateClient = Client.connect("http://localhost:8080")
+
+    // Route a call into a named scope
+    val svcResponse = restateClient.scope("tenant-123").service<MyService>().myHandler("Hi")
+
+    // Add a limit key for a hierarchical concurrency limit within the scope
+    val objResponse =
+        restateClient
+            .scope("tenant-123")
+            .toVirtualObject<MyObject>("Mary")
+            .request { myHandler("Hi") }
+            .options { limitKey = "premium/user42" }
+            .call()
+            .response()
+
+    // Fire-and-forget sends can be scoped too
+    restateClient.scope("tenant-123").toService<MyService>().request { myHandler("Hi") }.send()
+    // <end_scope>
+  }
 }

--- a/snippets/kotlin/src/main/kotlin/develop/IngressClient.kt
+++ b/snippets/kotlin/src/main/kotlin/develop/IngressClient.kt
@@ -2,7 +2,6 @@ package develop
 
 import dev.restate.client.Client
 import dev.restate.client.kotlin.*
-import dev.restate.client.kotlin.scope as scopeKt
 import dev.restate.common.Target
 import dev.restate.serde.kotlinx.*
 import kotlin.time.Duration.Companion.days
@@ -144,12 +143,12 @@ class IngressClient {
 
     // Route a call into a named scope
     // import dev.restate.client.kotlin.scope as scopeKt
-    val svcResponse = restateClient.scopeKt("tenant-123").service<MyService>().myHandler("Hi")
+    val svcResponse = restateClient.scope("tenant-123").service<MyService>().myHandler("Hi")
 
     // Add a limit key for a hierarchical concurrency limit within the scope
     val objResponse =
         restateClient
-            .scopeKt("tenant-123")
+            .scope("tenant-123")
             .toVirtualObject<MyObject>("Mary")
             .request { myHandler("Hi") }
             .options { limitKey = "premium/user42" }
@@ -157,7 +156,7 @@ class IngressClient {
             .response()
 
     // Fire-and-forget sends can be scoped too
-    restateClient.scopeKt("tenant-123").toService<MyService>().request { myHandler("Hi") }.send()
+    restateClient.scope("tenant-123").toService<MyService>().request { myHandler("Hi") }.send()
     // <end_scope>
   }
 }

--- a/snippets/kotlin/src/main/kotlin/develop/IngressClient.kt
+++ b/snippets/kotlin/src/main/kotlin/develop/IngressClient.kt
@@ -2,6 +2,7 @@ package develop
 
 import dev.restate.client.Client
 import dev.restate.client.kotlin.*
+import dev.restate.client.kotlin.scope as scopeKt
 import dev.restate.common.Target
 import dev.restate.serde.kotlinx.*
 import kotlin.time.Duration.Companion.days
@@ -142,12 +143,13 @@ class IngressClient {
     val restateClient = Client.connect("http://localhost:8080")
 
     // Route a call into a named scope
-    val svcResponse = restateClient.scope("tenant-123").service<MyService>().myHandler("Hi")
+    // import dev.restate.client.kotlin.scope as scopeKt
+    val svcResponse = restateClient.scopeKt("tenant-123").service<MyService>().myHandler("Hi")
 
     // Add a limit key for a hierarchical concurrency limit within the scope
     val objResponse =
         restateClient
-            .scope("tenant-123")
+            .scopeKt("tenant-123")
             .toVirtualObject<MyObject>("Mary")
             .request { myHandler("Hi") }
             .options { limitKey = "premium/user42" }
@@ -155,7 +157,7 @@ class IngressClient {
             .response()
 
     // Fire-and-forget sends can be scoped too
-    restateClient.scope("tenant-123").toService<MyService>().request { myHandler("Hi") }.send()
+    restateClient.scopeKt("tenant-123").toService<MyService>().request { myHandler("Hi") }.send()
     // <end_scope>
   }
 }

--- a/snippets/kotlin/src/main/kotlin/develop/IngressClient.kt
+++ b/snippets/kotlin/src/main/kotlin/develop/IngressClient.kt
@@ -142,7 +142,6 @@ class IngressClient {
     val restateClient = Client.connect("http://localhost:8080")
 
     // Route a call into a named scope
-    // import dev.restate.client.kotlin.scope as scopeKt
     val svcResponse = restateClient.scope("tenant-123").service<MyService>().myHandler("Hi")
 
     // Add a limit key for a hierarchical concurrency limit within the scope

--- a/snippets/kotlin/src/main/kotlin/develop/ServiceCommunication.kt
+++ b/snippets/kotlin/src/main/kotlin/develop/ServiceCommunication.kt
@@ -77,6 +77,36 @@ class ServiceCommunication {
     // <end_cancel>
   }
 
+  suspend fun scope() {
+    val request = ""
+    val objectKey = ""
+    val workflowId = ""
+
+    // <start_scope>
+    // Route a call into a named scope
+    val svcResponse = scope("tenant-123").service<MyService>().myHandler(request)
+
+    // Add a limit key for hierarchical concurrency limits within the scope
+    val wfResponse =
+        scope("tenant-123")
+            .toWorkflow<MyWorkflow>(workflowId)
+            .request { run(request) }
+            .options { limitKey = "premium/user42" }
+            .call()
+            .await()
+
+    // Scoped Virtual Object calls need
+    // RESTATE_EXPERIMENTAL_ENABLE_SCOPED_VIRTUAL_OBJECTS=true on the server
+    val objResponse = scope("tenant-123").virtualObject<MyObject>(objectKey).myHandler(request)
+    // <end_scope>
+
+    // <start_scope_request>
+    // The scope and limit key the invocation was submitted with
+    val invocationScope = request().scope
+    val invocationLimitKey = request().limitKey
+    // <end_scope_request>
+  }
+
   suspend fun generic() {
     val request = ""
 

--- a/snippets/python/src/develop/service_communication.py
+++ b/snippets/python/src/develop/service_communication.py
@@ -90,6 +90,25 @@ async def calling_handler(ctx: Context, arg):
     )
     # <end_idempotency_key>
 
+    # <start_scope>
+    # Route a call into a named scope
+    response = await ctx.scope("tenant-123").service_call(my_service_handler, arg="Hi")
+
+    # Add a limit key for hierarchical concurrency limits within the scope
+    response = await ctx.scope("tenant-123").workflow_call(
+        run, key="my_workflow_id", arg="Hi", limit_key="premium/user42"
+    )
+
+    # Fire-and-forget sends can be scoped too
+    ctx.scope("tenant-123").service_send(my_service_handler, arg="Hi")
+    # <end_scope>
+
+    # <start_scope_request>
+    # The scope and limit key the invocation was submitted with
+    scope = ctx.request().scope
+    limit_key = ctx.request().limit_key
+    # <end_scope_request>
+
     # <start_attach>
     # Send a request, get the invocation id
     handle = ctx.service_send(

--- a/snippets/ts/src/develop/clients/ingress.ts
+++ b/snippets/ts/src/develop/clients/ingress.ts
@@ -77,6 +77,31 @@ const myPlainTSFunction3 = async () => {
   // <end_delayed_call_node>
 };
 
+const scopedClient = async () => {
+  const request = { greeting: "Hi" };
+  // <start_scope>
+  const restateClient = clients.connect({ url: "http://localhost:8080" });
+
+  // Route a call into a named scope
+  const greet = await restateClient
+    .scope("tenant-123")
+    .serviceClient<MyService>({ name: "MyService" })
+    .greet(request);
+
+  // Add a limit key for a hierarchical concurrency limit within the scope
+  const count = await restateClient
+    .scope("tenant-123")
+    .objectClient<MyObject>({ name: "MyObject" }, "Mary")
+    .greet(request, clients.rpc.opts({ limitKey: "premium/user42" }));
+
+  // Fire-and-forget sends can be scoped too
+  await restateClient
+    .scope("tenant-123")
+    .serviceSendClient<MyService>({ name: "MyService" })
+    .greet(request);
+  // <end_scope>
+};
+
 const servicesIdempotent = async () => {
   const request = { greeting: "Hi" };
   const restateClient = clients.connect({ url: "http://localhost:8080" });

--- a/snippets/ts/src/develop/service_communication.ts
+++ b/snippets/ts/src/develop/service_communication.ts
@@ -134,6 +134,37 @@ const service = restate.service({
       ctx.cancel(invocationId);
       // <end_cancel>
     },
+    greetScoped: async (ctx: restate.Context) => {
+      // <start_scope>
+      // Route a call into a named scope
+      const svcResponse = await ctx
+        .scope("tenant-123")
+        .serviceClient(myService)
+        .myHandler("Hi");
+
+      // Add a limit key for hierarchical concurrency limits within the scope
+      const wfResponse = await ctx
+        .scope("tenant-123")
+        .workflowClient(myWorkflow, "wf-id")
+        .run("Hi", restate.rpc.opts({ limitKey: "premium/user42" }));
+
+      // Scoped Virtual Object calls need
+      // RESTATE_EXPERIMENTAL_ENABLE_SCOPED_VIRTUAL_OBJECTS=true on the server
+      const objResponse = await ctx
+        .scope("tenant-123")
+        .objectClient(myObject, "Mary")
+        .myHandler("Hi");
+
+      // Fire-and-forget sends can be scoped too
+      ctx.scope("tenant-123").serviceSendClient(myService).myHandler("Hi");
+      // <end_scope>
+
+      // <start_scope_request>
+      // The scope and limit key the invocation was submitted with
+      const scope = ctx.request().scope;
+      const limitKey = ctx.request().limitKey;
+      // <end_scope_request>
+    },
     greet6: async (ctx: restate.Context) => {
       // <start_export_definition>
       const response = await ctx


### PR DESCRIPTION
- add scoped service-to-service calls
- add scoped ingress calls with SDK clients
- fix nuance of that scope is part of identity of invocation and namespaces invocations